### PR TITLE
replace hard coded buffer sizes using #defines

### DIFF
--- a/indimail-mta-x/822addr.c
+++ b/indimail-mta-x/822addr.c
@@ -1,5 +1,8 @@
 /*
  * $Log: 822addr.c,v $
+ * Revision 1.5  2024-01-23 01:19:16+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.4  2021-08-29 23:27:08+05:30  Cprogrammer
  * define functions as noreturn
  *
@@ -107,7 +110,7 @@ main(int argc, char **argv)
 void
 getversion_822addr_c()
 {
-	static char    *x = "$Id: 822addr.c,v 1.4 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: 822addr.c,v 1.5 2024-01-23 01:19:16+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/822addr.c
+++ b/indimail-mta-x/822addr.c
@@ -22,11 +22,12 @@
 #include <case.h>
 #include <stralloc.h>
 #include <noreturn.h>
+#include "buffer_defs.h"
 
 #define FATAL "822addr: fatal: "
 
-static char     ssinbuf[1024];
-static char     ssoutbuf[512];
+static char     ssinbuf[BUFSIZE_IN];
+static char     ssoutbuf[BUFSIZE_OUT];
 static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
 static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
 static int      flag;

--- a/indimail-mta-x/822body.c
+++ b/indimail-mta-x/822body.c
@@ -20,14 +20,15 @@
 #include "error.h"
 #include "getln.h"
 #include "mess822.h"
+#include "buffer_defs.h"
 
 #define FATAL "822body: fatal: "
 
 stralloc        line = { 0 };
 int             match;
-static char     ssinbuf[1024];
+static char     ssinbuf[BUFSIZE_IN];
 static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
-static char     ssoutbuf[512];
+static char     ssoutbuf[BUFSIZE_OUT];
 static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
 
 int

--- a/indimail-mta-x/822body.c
+++ b/indimail-mta-x/822body.c
@@ -1,5 +1,8 @@
 /*
  * $Log: 822body.c,v $
+ * Revision 1.5  2024-01-23 01:19:48+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.4  2022-10-30 17:54:31+05:30  Cprogrammer
  * converted to ansic prototype
  *
@@ -68,7 +71,7 @@ main(int argc, char **argv)
 void
 getversion_822body_c()
 {
-	static char    *x = "$Id: 822body.c,v 1.4 2022-10-30 17:54:31+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: 822body.c,v 1.5 2024-01-23 01:19:48+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/822bodyfilter.c
+++ b/indimail-mta-x/822bodyfilter.c
@@ -1,5 +1,8 @@
 /*
  * $Log: 822bodyfilter.c,v $
+ * Revision 1.4  2024-01-23 01:19:54+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.3  2020-11-24 13:42:08+05:30  Cprogrammer
  * removed exit.h
  *
@@ -89,7 +92,7 @@ main(int argc, char **argv, char **envp)
 void
 getversion_822bodyfilter_c()
 {
-	static char    *x = "$Id: 822bodyfilter.c,v 1.3 2020-11-24 13:42:08+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: 822bodyfilter.c,v 1.4 2024-01-23 01:19:54+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/822bodyfilter.c
+++ b/indimail-mta-x/822bodyfilter.c
@@ -20,14 +20,15 @@
 #include "fd.h"
 #include "seek.h"
 #include "pathexec.h"
+#include "buffer_defs.h"
 
 #define FATAL "822bodyfilter: fatal: "
 
 stralloc        line = { 0 };
 int             match;
-static char     ssinbuf[1024];
+static char     ssinbuf[BUFSIZE_IN];
 static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
-static char     ssoutbuf[512];
+static char     ssoutbuf[BUFSIZE_OUT];
 static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
 
 int

--- a/indimail-mta-x/822fields.c
+++ b/indimail-mta-x/822fields.c
@@ -1,5 +1,8 @@
 /*
  * $Log: 822fields.c,v $
+ * Revision 1.5  2024-01-23 01:20:03+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.4  2020-11-28 12:43:14+05:30  Cprogrammer
  * +HeaderName feature by Erwin Hoffman: display all headers which have HeaderName as the initial text
  *
@@ -107,7 +110,7 @@ main(int argc, char **argv)
 void
 getversion_822fields_c()
 {
-	static char    *x = "$Id: 822fields.c,v 1.4 2020-11-28 12:43:14+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: 822fields.c,v 1.5 2024-01-23 01:20:03+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/822fields.c
+++ b/indimail-mta-x/822fields.c
@@ -21,14 +21,15 @@
 #include "mess822.h"
 #include "case.h"
 #include "stralloc.h"
+#include "buffer_defs.h"
 
 #define FATAL "822fields: fatal: "
 
 static int      flag, t = 2;
 stralloc        value = { 0 };
-static char     ssinbuf[1024];
+static char     ssinbuf[BUFSIZE_IN];
 static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
-static char     ssoutbuf[512];
+static char     ssoutbuf[BUFSIZE_OUT];
 static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
 
 mess822_header  h = MESS822_HEADER;

--- a/indimail-mta-x/822headerfilter.c
+++ b/indimail-mta-x/822headerfilter.c
@@ -22,16 +22,17 @@
 #include "mess822.h"
 #include "fd.h"
 #include "pathexec.h"
+#include "buffer_defs.h"
 
 #define FATAL "822headerfilter: fatal: "
 
 stralloc        line = { 0 };
 int             match;
 
-char            pipbuf[1024];
-static char     ssinbuf[1024];
+char            pipbuf[BUFSIZE_IN];
+static char     ssinbuf[BUFSIZE_IN];
 static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
-static char     ssoutbuf[512];
+static char     ssoutbuf[BUFSIZE_OUT];
 static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
 static substdio sspip;
 

--- a/indimail-mta-x/822headerfilter.c
+++ b/indimail-mta-x/822headerfilter.c
@@ -1,5 +1,8 @@
 /*
  * $Log: 822headerfilter.c,v $
+ * Revision 1.5  2024-01-23 01:20:09+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.4  2020-11-24 13:42:56+05:30  Cprogrammer
  * /usr/local/src/projects/rpmbuild/RPMS/x86_64/libqmail-devel-1.0-1.1.fc33.x86_64.rpm
  *
@@ -101,7 +104,7 @@ main(int argc, char **argv, char **envp)
 void
 getversion_822headerfilter_c()
 {
-	static char    *x = "$Id: 822headerfilter.c,v 1.4 2020-11-24 13:42:56+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: 822headerfilter.c,v 1.5 2024-01-23 01:20:09+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/822headerok.c
+++ b/indimail-mta-x/822headerok.c
@@ -18,10 +18,11 @@
 #include "error.h"
 #include "getln.h"
 #include "mess822.h"
+#include "buffer_defs.h"
 
 stralloc        line = { 0 };
 int             match;
-static char     ssinbuf[1024];
+static char     ssinbuf[BUFSIZE_IN];
 static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
 
 int

--- a/indimail-mta-x/822headerok.c
+++ b/indimail-mta-x/822headerok.c
@@ -1,5 +1,8 @@
 /*
  * $Log: 822headerok.c,v $
+ * Revision 1.5  2024-01-23 01:20:14+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.4  2022-10-30 17:55:00+05:30  Cprogrammer
  * converted to ansic prototype
  *
@@ -49,7 +52,7 @@ main(int argc, char **argv)
 void
 getversion_822headerok_c()
 {
-	static char    *x = "$Id: 822headerok.c,v 1.4 2022-10-30 17:55:00+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: 822headerok.c,v 1.5 2024-01-23 01:20:14+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/Makefile
+++ b/indimail-mta-x/Makefile
@@ -390,7 +390,7 @@ auto_control.o auto_prefix.o set_environment.o
 	auto_control.o auto_prefix.o set_environment.o $(QMAILLIB)
 
 condredirect.o: compile condredirect.c qmail.h \
-set_environment.h srs.h
+set_environment.h srs.h buffer_defs.h
 	./compile `grep -h -v "^#" conf-spf` condredirect.c
 
 condredirect.1: condredirect.9 conf-qmail conf-sysconfdir
@@ -666,7 +666,8 @@ forward.1: forward.9 conf-sysconfdir
 	| sed s}@controldir\@}"`head -1 conf-sysconfdir`/control"}g \
 	> forward.1
 
-forward.o: compile forward.c qmail.h set_environment.h hassrs.h
+forward.o: compile forward.c qmail.h set_environment.h hassrs.h \
+buffer_defs.h
 	./compile forward.c
 
 gfrom.o: \
@@ -778,7 +779,8 @@ load qhpsi.o auto_qmail.o get_uid.o auto_uids.o
 	./load qhpsi auto_qmail.o get_uid.o auto_uids.o \
 	-ldl $(QMAILLIB)
 
-qhpsi.o: compile qhpsi.c auto_qmail.h auto_uids.h qmail.h
+qhpsi.o: compile qhpsi.c auto_qmail.h auto_uids.h qmail.h \
+buffer_defs.h
 	./compile qhpsi.c
 
 qscanq: load qscanq.o auto_uids.o get_uid.o \
@@ -868,11 +870,12 @@ run-cleanq.o: compile run-cleanq.c auto_libexec.h \
 conf-servicedir
 	./compile -DSERVICEDIR=\"`head -1 conf-servicedir`\" run-cleanq.c
 
-custom_error.o: compile custom_error.c qmail.h
+custom_error.o: compile custom_error.c qmail.h \
+buffer_defs.h
 	./compile custom_error.c
 getqueue.o: \
 compile getqueue.c getqueue.h haslibrt.h custom_error.h \
-qmail.h conf-queue
+qmail.h buffer_defs.h conf-queue
 	./compile `grep -h -v "^#" conf-queue` getqueue.c
 
 qscanq-stdin: load qscanq-stdin.o auto_qmail.o \
@@ -895,7 +898,7 @@ do_ripmime.o: compile do_ripmime.c exitcodes.h
 	./compile do_ripmime.c
 
 do_scan.o: compile do_scan.c exitcodes.h qregex.h control.h \
-variables.h auto_control.h qmail.h
+variables.h auto_control.h qmail.h buffer_defs.h
 	./compile do_scan.c
 
 auto_ripmime_cmd.c: auto-strarr conf-ripmime-cmd
@@ -1084,7 +1087,7 @@ qmail-inject.8: qmail-inject.9 conf-prefix conf-qmail conf-sysconfdir
 qmail-inject.o: \
 compile qmail-inject.c hfield.h control.h \
 qmail.h quote.h headerbody.h newfield.h envrules.h \
-hassrs.h set_environment.h conf-srs
+buffer_defs.h hassrs.h set_environment.h conf-srs
 	./compile qmail-inject.c
 
 envrules.o: \
@@ -1132,7 +1135,7 @@ set_environment.o socket.lib srs.lib
 qmail-local.o: \
 compile qmail-local.c quote.h qmail.h slurpclose.h \
 gfrom.h auto_patrn.h control.h variables.h hassrs.h \
-syncdir.h maildir_deliver.h conf-sync conf-mailarch
+syncdir.h buffer_defs.h maildir_deliver.h conf-sync conf-mailarch
 	./compile `grep -h -v "^#" conf-sync conf-mailarch` qmail-local.c
 
 qmail-local.8:\
@@ -1264,7 +1267,7 @@ auto_control.o socket.lib
 qmail-qmqpc.o: \
 compile qmail-qmqpc.c auto_control.h slurpclose.h ip.h \
 timeoutconn.h control.h variables.h qmail.h socket.h \
-haveip6.h conf-ip
+haveip6.h buffer_defs.h conf-ip
 	./compile `grep -h -v "^#" conf-ip` qmail-qmqpc.c
 
 qmail-qmqpd: \
@@ -1273,7 +1276,7 @@ load qmail-qmqpd.o received.o qmail.o auto_prefix.o
 	$(static_option) $(QMAILLIB) $(dynamic_option)
 
 qmail-qmqpd.o: \
-compile qmail-qmqpd.c qmail.h received.h
+compile qmail-qmqpd.c buffer_defs.h qmail.h received.h
 	./compile qmail-qmqpd.c
 
 qmail-qmtpd: \
@@ -1285,12 +1288,12 @@ qmail.o auto_control.o auto_prefix.o variables.o
 
 qmail-qmtpd.o: \
 compile qmail-qmtpd.c qmail.h rcpthosts.h control.h received.h \
-recipients.h
+buffer_defs.h recipients.h
 	./compile qmail-qmtpd.c
 
 process_queue.o: \
 compile process_queue.c control.h auto_qmail.h set_environment.h \
-process_queue.h conf-queue
+process_queue.h buffer_defs.h conf-queue
 	./compile `grep -h -v "^#" conf-queue` process_queue.c
 
 qmail-qread: \
@@ -1305,7 +1308,7 @@ set_environment.o queue_load.o process_queue.o rt.lib
 qmail-qread.o: \
 compile qmail-qread.c auto_qmail.h auto_split.h readsubdir.h \
 fmtqfn.h haslibrt.h control.h variables.h process_queue.h \
-queue_load.h set_environment.h conf-queue
+queue_load.h buffer_defs.h set_environment.h conf-queue
 	./compile `grep -h -v "^#" conf-queue` qmail-qread.c
 
 qmail-qread.8: qmail-qread.9 conf-sysconfdir conf-split
@@ -1327,7 +1330,8 @@ auto_qmail.o custom_error.o getqueue.o dns.lib socket.lib rt.lib
 	$(dynamic_option) `cat dns.lib socket.lib rt.lib`
 
 qmail-multi.o: \
-compile qmail-multi.c qmulti.h qmail.h mailfilter.h conf-queue
+compile qmail-multi.c qmulti.h buffer_defs.h qmail.h mailfilter.h \
+conf-queue
 	./compile `grep -h -v "^#" conf-queue` qmail-multi.c
 
 qmail-multi.8: \
@@ -1343,7 +1347,7 @@ custom_error.o getqueue.o rt.lib
 	$(dynamic_option) `cat rt.lib`
 
 qmail-spamfilter.o: \
-compile qmail-spamfilter.c qmulti.h qmail.h
+compile qmail-spamfilter.c qmulti.h qmail.h buffer_defs.h
 	./compile qmail-spamfilter.c
 
 qmail-spamfilter.8: \
@@ -1355,12 +1359,12 @@ qmail-spamfilter.9 conf-prefix conf-qmail
 
 qmulti.o: \
 compile qmulti.c auto_qmail.h control.h qmulti.h qmail.h \
-auto_prefix.h qscheduler.h custom_error.h haslibrt.h qmail.h \
+auto_prefix.h qscheduler.h custom_error.h haslibrt.h buffer_defs.h \
 conf-queue
 	./compile `grep -h -v "^#" conf-queue` qmulti.c
 
 mailfilter.o: \
-compile mailfilter.c mailfilter.h qmulti.h qmail.h
+compile mailfilter.c mailfilter.h qmulti.h qmail.h buffer_defs.h
 	./compile mailfilter.c
 
 spawn-filter: \
@@ -1376,7 +1380,7 @@ socket.lib dns.lib
 
 spawn-filter.o: \
 compile spawn-filter.c control.h auto_qmail.h variables.h qregex.h \
-report.h getDomainToken.h auto_prefix.h
+report.h getDomainToken.h auto_prefix.h buffer_defs.h
 	./compile spawn-filter.c
 
 spawn-filter.8: \
@@ -1454,7 +1458,8 @@ qmail-queue.o: \
 compile qmail-queue.c triggerpull.h do_match.h \
 control.h auto_uids.h fmtqfn.h variables.h qmail.h \
 qscheduler.h syncdir.h haslibrt.h auto_prefix.h \
-auto_split.h conf-sync conf-qhpsi conf-ip conf-mailarch
+auto_split.h buffer_defs.h conf-sync conf-qhpsi \
+conf-ip conf-mailarch
 	./compile `grep -h -v "^#" conf-sync conf-qhpsi conf-ip conf-mailarch` \
 	qmail-queue.c
 
@@ -1504,7 +1509,8 @@ dns.lib dkim.lib rt.lib conf-ld-$(SYSTEM) load
 
 qmail-dkim.o: \
 compile qmail-dkim.c qmail.h control.h hasdkim.h variables.h \
-auto_control.h qmulti.h pidopen.h custom_error.h getDomainToken.h
+auto_control.h qmulti.h pidopen.h custom_error.h getDomainToken.h \
+buffer_defs.h
 	./compile -I/usr/include/dkim -I/usr/local/include/dkim \
 		-I../libdkim2-x -I/opt/local/include/dkim qmail-dkim.c
 
@@ -1586,7 +1592,7 @@ compile qmail-remote.c control.h dns.h quote.h ip.h auto_sysconfdir.h \
 ipalloc.h query_skt.h ipme.h tcpto.h timeoutconn.h haveip6.h socket.h \
 variables.h auto_control.h cdb_match.h haslibgsasl.h dossl.h parse_env.h \
 hastlsa.h tlsacheck.h fn_handler.h tlsarralloc.h hassmtputf8.h batv.h \
-varargs.h conf-tls conf-ip conf-batv conf-mxps conf-smtputf8
+buffer_defs.h varargs.h conf-tls conf-ip conf-batv conf-mxps conf-smtputf8
 	./compile `grep -h -v "^#" conf-tls conf-ip conf-mxps \
 		conf-batv` qmail-remote.c
 
@@ -1614,7 +1620,7 @@ qmail-send.o: \
 compile qmail-send.c control.h auto_qmail.h trigger.h newfield.h \
 quote.h qmail.h qsutil.h prioq.h envrules.h syncdir.h delivery_rate.h \
 fmtqfn.h readsubdir.h variables.h auto_control.h auto_split.h hassrs.h \
-varargs.h haslibrt.h conf-mime conf-sync conf-batv conf-srs \
+buffer_defs.h varargs.h haslibrt.h conf-mime conf-sync conf-batv conf-srs \
 conf-bounce conf-loglock
 	./compile `grep -h -v "^#" conf-mime conf-sync conf-batv \
 	conf-bounce conf-loglock` qmail-send.c
@@ -1641,7 +1647,7 @@ auto_split.o auto_control.o variables.o syncdir.o rt.lib
 todo-proc.o: \
 compile todo-proc.c auto_qmail.h control.h syncdir.h varargs.h \
 fmtqfn.h readsubdir.h trigger.h variables.h qscheduler.h \
-haslibrt.h auto_control.h auto_split.h auto_uids.h conf-sync
+buffer_defs.h haslibrt.h auto_control.h auto_split.h auto_uids.h conf-sync
 	./compile `grep -h -v "^#" conf-sync` todo-proc.c
 
 todo-proc.8: \
@@ -1676,7 +1682,8 @@ slowq-send.o: \
 compile slowq-send.c control.h auto_qmail.h trigger.h newfield.h \
 quote.h qmail.h qsutil.h prioq.h envrules.h syncdir.h delivery_rate.h \
 fmtqfn.h readsubdir.h variables.h auto_control.h auto_split.h hassrs.h \
-varargs.h conf-mime conf-sync conf-batv conf-loglock conf-bounce conf-srs
+varargs.h buffer_defs.h conf-mime conf-sync conf-batv conf-loglock \
+conf-bounce conf-srs
 	./compile `grep -h -v "^#" conf-mime conf-sync conf-batv \
 	conf-loglock conf-bounce conf-srs` slowq-send.c
 
@@ -1733,7 +1740,8 @@ qmta-send.o: \
 compile qmta-send.c qsutil.h fmtqfn.h readsubdir.h trigger.h \
 variables.h prioq.h qmail.h newfield.h quote.h set_environment.h \
 auto_split.h auto_uids.h auto_prefix.h set_queuedir.h varargs.h \
-conf-mime conf-sync conf-batv conf-srs conf-loglock conf-bounce
+buffer_defs.h conf-mime conf-sync conf-batv conf-srs conf-loglock \
+conf-bounce
 	./compile `grep -h -v "^#" conf-mime conf-sync conf-batv \
 	conf-loglock conf-bounce conf-srs` qmta-send.c
 
@@ -1918,9 +1926,9 @@ smtpd.o: \
 compile smtpd.c control.h received.h varargs.h \
 ipme.h ip.h ipalloc.h qmail.h recipients.h greylist.h \
 variables.h rcpthosts.h etrn.h batv.h do_match.h \
-envrules.h tablematch.h qregex.h sqlmatch.h \
+envrules.h tablematch.h qregex.h sqlmatch.h buffer_defs.h \
 smtp_plugin.h auto_prefix.h hasmysql.h indimail_stub.h \
-auto_control.h dns.h hassmtputf8.h haslibgsasl.h \
+auto_control.h dns.h hassmtputf8.h haslibgsasl.h buffer_defs.h \
 hassrs.h valid_hname.h conf-tls conf-spf conf-ip conf-plugin \
 conf-batv conf-smtputf8 mysql_config mysql_inc
 	./compile `grep -h -v "^#" conf-tls conf-spf \
@@ -1933,7 +1941,7 @@ qmail-smtpd.9 conf-qmail conf-sysconfdir conf-prefix
 mini-smtpd: \
 load mini-smtpd.o ipme.o socket_v6any.o socket_v4mappedprefix.o \
 ipalloc.o ip.o variables.o rcpthosts.o control.o qmail.o \
-received.o auto_control.o auto_qmail.o auto_prefix.o
+buffer_defs.h received.o auto_control.o auto_qmail.o auto_prefix.o
 	./load mini-smtpd ipme.o socket_v6any.o socket_v4mappedprefix.o \
 	ipalloc.o ip.o variables.o rcpthosts.o control.o qmail.o \
 	received.o auto_qmail.o auto_control.o auto_prefix.o \
@@ -1941,7 +1949,7 @@ received.o auto_control.o auto_qmail.o auto_prefix.o
 
 mini-smtpd.o: \
 compile mini-smtpd.c auto_qmail.h control.h received.h ipme.h ip.h \
-qmail.h rcpthosts.h
+qmail.h rcpthosts.h buffer_defs.h
 	./compile mini-smtpd.c
 
 mail_acl.o: compile mail_acl.c wildmat.h varargs.h
@@ -2083,7 +2091,7 @@ qmail-users.9 conf-qmail conf-sysconfdir
 	| sed s}@assign@}"`head -1 conf-sysconfdir`/users"}g \
 	> qmail-users.5
 
-qmail.o: compile qmail.c qmail.h auto_prefix.h
+qmail.o: compile qmail.c qmail.h auto_prefix.h buffer_defs.h
 	./compile qmail.c
 
 qreceipt: \
@@ -2101,7 +2109,7 @@ qreceipt.1: qreceipt.9 conf-sysconfdir
 
 qreceipt.o: \
 compile qreceipt.c hfield.h \
-headerbody.h quote.h qmail.h set_environment.h
+headerbody.h quote.h qmail.h set_environment.h buffer_defs.h
 	./compile qreceipt.c
 
 qsmhook: \
@@ -2136,7 +2144,7 @@ compile readsubdir.c readsubdir.h auto_split.h
 	./compile readsubdir.c
 
 received.o: \
-compile received.c qmail.h received.h
+compile received.c qmail.h received.h buffer_defs.h
 	./compile received.c
 
 remoteinfo.o: \
@@ -2156,7 +2164,7 @@ rrforward.1: rrforward.9 conf-sysconfdir
 	> rrforward.1
 
 rrforward.o: \
-compile rrforward.c qmail.h set_environment.h
+compile rrforward.c qmail.h set_environment.h buffer_defs.h
 	./compile rrforward.c
 
 sendmail: \
@@ -2390,7 +2398,7 @@ auto_prefix.o auto_control.o variables.o srs.lib
 	-L../libsrs2-x/libsrs2/.libs `cat srs.lib` $(QMAILLIB)
 
 srsfilter.o: \
-compile srsfilter.c qmail.h srs.h hassrs.h
+compile srsfilter.c qmail.h srs.h hassrs.h buffer_defs.h
 	./compile srsfilter.c
 
 strsalloc.o: \
@@ -2489,7 +2497,7 @@ load qbase64.o
 	./load qbase64 $(QMAILLIB)
 
 qbase64.o: \
-compile qbase64.c
+compile qbase64.c buffer_defs.h
 	./compile qbase64.c
 
 maildirdeliver: load maildirdeliver.o maildir_deliver.o \
@@ -2529,7 +2537,7 @@ qregex.o wildmat.o auto_prefix.o conf-srs
 
 autoresponder.o: \
 compile autoresponder.c auto_sysconfdir.h control.h ip.h ipme.h \
-auto_prefix.h quote.h qregex.h conf-mime hassrs.h
+auto_prefix.h quote.h qregex.h conf-mime hassrs.h buffer_defs.h
 	./compile -DMAKE_SEEKABLE -DQUOTE `grep -h -v "^#" conf-mime` autoresponder.c
 
 822field: \
@@ -2552,52 +2560,53 @@ compile 822header.c
 822body: load 822body.o
 	./load 822body $(QMAILLIB)
 
-822body.o: compile 822body.c
+822body.o: compile 822body.c buffer_defs.h
 	./compile 822body.c
 
 822headerok: load 822headerok.o
 	./load 822headerok $(QMAILLIB)
 
-822headerok.o: compile 822headerok.c
+822headerok.o: compile 822headerok.c buffer_defs.h
 	./compile 822headerok.c
 
 822bodyfilter: load 822bodyfilter.o
 	./load 822bodyfilter $(QMAILLIB)
 
-822bodyfilter.o: compile 822bodyfilter.c
+822bodyfilter.o: compile 822bodyfilter.c buffer_defs.h
 	./compile 822bodyfilter.c
 
 822headerfilter: load 822headerfilter.o
 	./load 822headerfilter $(QMAILLIB)
 
-822headerfilter.o: compile 822headerfilter.c
+822headerfilter.o: compile 822headerfilter.c buffer_defs.h
 	./compile 822headerfilter.c
 
 822addr: load 822addr.o
 	./load 822addr $(QMAILLIB)
 
-822addr.o: compile 822addr.c
+822addr.o: compile 822addr.c buffer_defs.h
 	./compile 822addr.c
 
 822fields: load 822fields.o
 	./load 822fields $(QMAILLIB)
 
-822fields.o: compile 822fields.c
+822fields.o: compile 822fields.c buffer_defs.h
 	./compile 822fields.c
 
 checkaddr: load checkaddr.o
 	./load checkaddr $(QMAILLIB)
 
-checkaddr.o: compile checkaddr.c
+checkaddr.o: compile checkaddr.c buffer_defs.h
 	./compile checkaddr.c
 
 checkdomain: load checkdomain.o
 	./load checkdomain $(QMAILLIB)
 
-checkdomain.o: compile checkdomain.c
+checkdomain.o: compile checkdomain.c buffer_defs.h
 	./compile checkdomain.c
 
-filterto.o: compile filterto.c qmail.h set_environment.h
+filterto.o: compile filterto.c qmail.h set_environment.h \
+buffer_defs.h
 	./compile filterto.c
 
 filterto: load filterto.o qmail.o auto_prefix.o \
@@ -2622,13 +2631,13 @@ compile condtomaildir.c maildir_deliver.h
 iftoccfrom: load iftoccfrom.o
 	./load iftoccfrom $(QMAILLIB)
 
-iftoccfrom.o: compile iftoccfrom.c
+iftoccfrom.o: compile iftoccfrom.c buffer_defs.h
 	./compile iftoccfrom.c
 
 ifaddr: load ifaddr.o
 	./load ifaddr $(QMAILLIB)
 
-ifaddr.o: compile ifaddr.c
+ifaddr.o: compile ifaddr.c buffer_defs.h
 	./compile ifaddr.c
 
 replier: load replier.o qmail.o variables.o getconf.o \
@@ -2677,7 +2686,7 @@ maildirserial.1: maildirserial.9 conf-sysconfdir
 
 maildirserial.o: \
 compile maildirserial.c prioq.h variables.h qmail.h \
-auto_control.h set_environment.h conf-mime
+auto_control.h buffer_defs.h set_environment.h conf-mime
 	./compile `grep -h -v "^#" conf-mime` maildirserial.c
 
 serialcmd: load serialcmd.o quote.o
@@ -2991,20 +3000,20 @@ columnt.o: compile columnt.c slurpclose.h \
 qmail-cat: load qmail-cat.o
 	./load qmail-cat $(QMAILLIB)
 
-qmail-cat.o: compile qmail-cat.c
+qmail-cat.o: compile qmail-cat.c buffer_defs.h
 	./compile qmail-cat.c
 
 qaes: load qaes.o
 	./load qaes -lcrypto $(QMAILLIB)
 
-qaes.o: compile qaes.c
+qaes.o: compile qaes.c buffer_defs.h
 	./compile qaes.c
 
 qarf: \
 load qarf.o
 	./load qarf $(QMAILLIB)
 
-qarf.o: compile qarf.c
+qarf.o: compile qarf.c buffer_defs.h
 	./compile qarf.c
 
 set_environment.o: compile set_environment.c \
@@ -3019,7 +3028,7 @@ auto_control.o set_environment.o
 	$(QMAILLIB)
 
 qnotify.o: \
-compile qnotify.c qmail.h set_environment.h
+compile qnotify.c qmail.h set_environment.h buffer_defs.h
 	./compile qnotify.c
 
 rrt: \
@@ -3029,7 +3038,7 @@ auto_prefix.o auto_control.o set_environment.o
 	auto_control.o set_environment.o $(QMAILLIB)
 
 rrt.o: \
-compile rrt.c control.h qmail.h \
+compile rrt.c control.h qmail.h buffer_defs.h \
 variables.h set_environment.h
 	./compile rrt.c
 
@@ -3038,7 +3047,7 @@ load qmail-poppass.o auto_uids.o
 	./load qmail-poppass auto_uids.o $(QMAILLIB)
 
 qmail-poppass.o: \
-compile qmail-poppass.c auto_uids.h
+compile qmail-poppass.c auto_uids.h buffer_defs.h
 	./compile qmail-poppass.c
 
 rpmattr: \
@@ -3072,7 +3081,7 @@ auto_prefix.o control.o auto_control.o variables.o
 	auto_prefix.o auto_control.o variables.o control.o \
 	$(static_option) $(QMAILLIB) $(dynamic_option)
 
-ofmipd.o: compile ofmipd.c qmail.h \
+ofmipd.o: compile ofmipd.c qmail.h buffer_defs.h \
 variables.h rwhconfig.h
 	./compile ofmipd.c
 
@@ -3100,7 +3109,7 @@ new-inject.1: new-inject.9 conf-sysconfdir
 	> new-inject.1
 
 new-inject.o: \
-compile new-inject.c qmail.h \
+compile new-inject.c qmail.h buffer_defs.h \
 rwhconfig.h set_environment.h
 	./compile new-inject.c
 
@@ -3200,7 +3209,7 @@ dot-forward.1: dot-forward.9 conf-sysconfdir
 	> dot-forward.1
 
 dot-forward.o: compile dot-forward.c control.h qmail.h \
-set_environment.h
+buffer_defs.h set_environment.h
 	./compile dot-forward.c
 
 fastforward: \
@@ -3212,7 +3221,7 @@ auto_control.o auto_prefix.o set_environment.o
 
 fastforward.o: \
 compile fastforward.c strset.h qmail.h slurpclose.h \
-set_environment.h
+buffer_defs.h set_environment.h
 	./compile fastforward.c
 
 fastforward.1: fastforward.9 conf-sysconfdir
@@ -3283,7 +3292,7 @@ sortedtest: load sortedtest.o sorted.o
 sortedtest.o: compile sortedtest.c sorted.h
 	./compile sortedtest.c
 
-generic.o: compile generic.c qmail.h
+generic.o: compile generic.c buffer_defs.h qmail.h
 	./compile generic.c
 
 relaytest.o: compile relaytest.c
@@ -3391,7 +3400,7 @@ variables.o rt.lib
 	getqueue.o `cat rt.lib` $(QMAILLIB)
 
 qmail-qfilter.o: \
-compile qmail-qfilter.c qmail.h qmulti.h custom_error.h
+compile qmail-qfilter.c buffer_defs.h qmail.h qmulti.h custom_error.h
 	./compile qmail-qfilter.c
 
 qfrontend.1: qfrontend.9 conf-libexec
@@ -3443,7 +3452,7 @@ qmail-daned.9 conf-qmail conf-sysconfdir
 starttls.o: compile starttls.c conf-tls hastlsa.h conf-ip \
 socket.h ip.h dns.h control.h variables.h tlsacheck.h \
 ipalloc.h tlsarralloc.h auto_control.h auto_sysconfdir.h \
-dossl.h haveip6.h varargs.h
+buffer_defs.h dossl.h haveip6.h varargs.h
 	./compile `grep -h -v "^#" conf-ip conf-tls` starttls.c
 
 tlsacheck.o: \
@@ -3594,7 +3603,7 @@ dns.lib rt.lib
 
 surblfilter.o: \
 compile surblfilter.c control.h dns.h ip.h \
-ipalloc.h variables.h qmail.h auto_control.h
+ipalloc.h variables.h buffer_defs.h qmail.h auto_control.h
 	./compile surblfilter.c
 
 surblqueue: \
@@ -3831,7 +3840,7 @@ compile filterit.c filterit.h
 
 filterit_sub.o: \
 compile filterit_sub.c cdb_match.o quote.h maildir_deliver.h \
-qmail.h set_environment.h filterit.h hassrs.h
+buffer_defs.h qmail.h set_environment.h filterit.h hassrs.h
 	./compile filterit_sub.c
 
 filterit.1: filterit.9 conf-sysconfdir conf-prefix

--- a/indimail-mta-x/Makefile
+++ b/indimail-mta-x/Makefile
@@ -390,7 +390,7 @@ auto_control.o auto_prefix.o set_environment.o
 	auto_control.o auto_prefix.o set_environment.o $(QMAILLIB)
 
 condredirect.o: compile condredirect.c qmail.h \
-set_environment.h srs.h buffer_defs.h
+set_environment.h srs.h
 	./compile `grep -h -v "^#" conf-spf` condredirect.c
 
 condredirect.1: condredirect.9 conf-qmail conf-sysconfdir
@@ -666,8 +666,7 @@ forward.1: forward.9 conf-sysconfdir
 	| sed s}@controldir\@}"`head -1 conf-sysconfdir`/control"}g \
 	> forward.1
 
-forward.o: compile forward.c qmail.h set_environment.h hassrs.h \
-buffer_defs.h
+forward.o: compile forward.c qmail.h set_environment.h hassrs.h
 	./compile forward.c
 
 gfrom.o: \
@@ -779,8 +778,7 @@ load qhpsi.o auto_qmail.o get_uid.o auto_uids.o
 	./load qhpsi auto_qmail.o get_uid.o auto_uids.o \
 	-ldl $(QMAILLIB)
 
-qhpsi.o: compile qhpsi.c auto_qmail.h auto_uids.h qmail.h \
-buffer_defs.h
+qhpsi.o: compile qhpsi.c auto_qmail.h auto_uids.h qmail.h
 	./compile qhpsi.c
 
 qscanq: load qscanq.o auto_uids.o get_uid.o \
@@ -870,12 +868,12 @@ run-cleanq.o: compile run-cleanq.c auto_libexec.h \
 conf-servicedir
 	./compile -DSERVICEDIR=\"`head -1 conf-servicedir`\" run-cleanq.c
 
-custom_error.o: compile custom_error.c qmail.h \
-buffer_defs.h
+custom_error.o: compile custom_error.c qmail.h
 	./compile custom_error.c
+
 getqueue.o: \
 compile getqueue.c getqueue.h haslibrt.h custom_error.h \
-qmail.h buffer_defs.h conf-queue
+qmail.h conf-queue
 	./compile `grep -h -v "^#" conf-queue` getqueue.c
 
 qscanq-stdin: load qscanq-stdin.o auto_qmail.o \
@@ -898,7 +896,7 @@ do_ripmime.o: compile do_ripmime.c exitcodes.h
 	./compile do_ripmime.c
 
 do_scan.o: compile do_scan.c exitcodes.h qregex.h control.h \
-variables.h auto_control.h qmail.h buffer_defs.h
+variables.h auto_control.h qmail.h
 	./compile do_scan.c
 
 auto_ripmime_cmd.c: auto-strarr conf-ripmime-cmd
@@ -1087,7 +1085,7 @@ qmail-inject.8: qmail-inject.9 conf-prefix conf-qmail conf-sysconfdir
 qmail-inject.o: \
 compile qmail-inject.c hfield.h control.h \
 qmail.h quote.h headerbody.h newfield.h envrules.h \
-buffer_defs.h hassrs.h set_environment.h conf-srs
+hassrs.h set_environment.h conf-srs
 	./compile qmail-inject.c
 
 envrules.o: \
@@ -1135,7 +1133,7 @@ set_environment.o socket.lib srs.lib
 qmail-local.o: \
 compile qmail-local.c quote.h qmail.h slurpclose.h \
 gfrom.h auto_patrn.h control.h variables.h hassrs.h \
-syncdir.h buffer_defs.h maildir_deliver.h conf-sync conf-mailarch
+syncdir.h maildir_deliver.h conf-sync conf-mailarch
 	./compile `grep -h -v "^#" conf-sync conf-mailarch` qmail-local.c
 
 qmail-local.8:\
@@ -1293,7 +1291,7 @@ buffer_defs.h recipients.h
 
 process_queue.o: \
 compile process_queue.c control.h auto_qmail.h set_environment.h \
-process_queue.h buffer_defs.h conf-queue
+process_queue.h conf-queue
 	./compile `grep -h -v "^#" conf-queue` process_queue.c
 
 qmail-qread: \
@@ -1308,7 +1306,7 @@ set_environment.o queue_load.o process_queue.o rt.lib
 qmail-qread.o: \
 compile qmail-qread.c auto_qmail.h auto_split.h readsubdir.h \
 fmtqfn.h haslibrt.h control.h variables.h process_queue.h \
-queue_load.h buffer_defs.h set_environment.h conf-queue
+queue_load.h set_environment.h conf-queue
 	./compile `grep -h -v "^#" conf-queue` qmail-qread.c
 
 qmail-qread.8: qmail-qread.9 conf-sysconfdir conf-split
@@ -1330,7 +1328,7 @@ auto_qmail.o custom_error.o getqueue.o dns.lib socket.lib rt.lib
 	$(dynamic_option) `cat dns.lib socket.lib rt.lib`
 
 qmail-multi.o: \
-compile qmail-multi.c qmulti.h buffer_defs.h qmail.h mailfilter.h \
+compile qmail-multi.c qmulti.h qmail.h mailfilter.h \
 conf-queue
 	./compile `grep -h -v "^#" conf-queue` qmail-multi.c
 
@@ -1347,7 +1345,7 @@ custom_error.o getqueue.o rt.lib
 	$(dynamic_option) `cat rt.lib`
 
 qmail-spamfilter.o: \
-compile qmail-spamfilter.c qmulti.h qmail.h buffer_defs.h
+compile qmail-spamfilter.c qmulti.h qmail.h
 	./compile qmail-spamfilter.c
 
 qmail-spamfilter.8: \
@@ -1359,12 +1357,12 @@ qmail-spamfilter.9 conf-prefix conf-qmail
 
 qmulti.o: \
 compile qmulti.c auto_qmail.h control.h qmulti.h qmail.h \
-auto_prefix.h qscheduler.h custom_error.h haslibrt.h buffer_defs.h \
+auto_prefix.h qscheduler.h custom_error.h haslibrt.h \
 conf-queue
 	./compile `grep -h -v "^#" conf-queue` qmulti.c
 
 mailfilter.o: \
-compile mailfilter.c mailfilter.h qmulti.h qmail.h buffer_defs.h
+compile mailfilter.c mailfilter.h qmulti.h qmail.h
 	./compile mailfilter.c
 
 spawn-filter: \
@@ -1620,7 +1618,7 @@ qmail-send.o: \
 compile qmail-send.c control.h auto_qmail.h trigger.h newfield.h \
 quote.h qmail.h qsutil.h prioq.h envrules.h syncdir.h delivery_rate.h \
 fmtqfn.h readsubdir.h variables.h auto_control.h auto_split.h hassrs.h \
-buffer_defs.h varargs.h haslibrt.h conf-mime conf-sync conf-batv conf-srs \
+varargs.h haslibrt.h conf-mime conf-sync conf-batv conf-srs \
 conf-bounce conf-loglock
 	./compile `grep -h -v "^#" conf-mime conf-sync conf-batv \
 	conf-bounce conf-loglock` qmail-send.c
@@ -1647,7 +1645,7 @@ auto_split.o auto_control.o variables.o syncdir.o rt.lib
 todo-proc.o: \
 compile todo-proc.c auto_qmail.h control.h syncdir.h varargs.h \
 fmtqfn.h readsubdir.h trigger.h variables.h qscheduler.h \
-buffer_defs.h haslibrt.h auto_control.h auto_split.h auto_uids.h conf-sync
+haslibrt.h auto_control.h auto_split.h auto_uids.h conf-sync
 	./compile `grep -h -v "^#" conf-sync` todo-proc.c
 
 todo-proc.8: \
@@ -1682,7 +1680,7 @@ slowq-send.o: \
 compile slowq-send.c control.h auto_qmail.h trigger.h newfield.h \
 quote.h qmail.h qsutil.h prioq.h envrules.h syncdir.h delivery_rate.h \
 fmtqfn.h readsubdir.h variables.h auto_control.h auto_split.h hassrs.h \
-varargs.h buffer_defs.h conf-mime conf-sync conf-batv conf-loglock \
+varargs.h conf-mime conf-sync conf-batv conf-loglock \
 conf-bounce conf-srs
 	./compile `grep -h -v "^#" conf-mime conf-sync conf-batv \
 	conf-loglock conf-bounce conf-srs` slowq-send.c
@@ -1740,7 +1738,7 @@ qmta-send.o: \
 compile qmta-send.c qsutil.h fmtqfn.h readsubdir.h trigger.h \
 variables.h prioq.h qmail.h newfield.h quote.h set_environment.h \
 auto_split.h auto_uids.h auto_prefix.h set_queuedir.h varargs.h \
-buffer_defs.h conf-mime conf-sync conf-batv conf-srs conf-loglock \
+conf-mime conf-sync conf-batv conf-srs conf-loglock \
 conf-bounce
 	./compile `grep -h -v "^#" conf-mime conf-sync conf-batv \
 	conf-loglock conf-bounce conf-srs` qmta-send.c
@@ -1928,7 +1926,7 @@ ipme.h ip.h ipalloc.h qmail.h recipients.h greylist.h \
 variables.h rcpthosts.h etrn.h batv.h do_match.h \
 envrules.h tablematch.h qregex.h sqlmatch.h buffer_defs.h \
 smtp_plugin.h auto_prefix.h hasmysql.h indimail_stub.h \
-auto_control.h dns.h hassmtputf8.h haslibgsasl.h buffer_defs.h \
+auto_control.h dns.h hassmtputf8.h haslibgsasl.h \
 hassrs.h valid_hname.h conf-tls conf-spf conf-ip conf-plugin \
 conf-batv conf-smtputf8 mysql_config mysql_inc
 	./compile `grep -h -v "^#" conf-tls conf-spf \
@@ -1941,7 +1939,7 @@ qmail-smtpd.9 conf-qmail conf-sysconfdir conf-prefix
 mini-smtpd: \
 load mini-smtpd.o ipme.o socket_v6any.o socket_v4mappedprefix.o \
 ipalloc.o ip.o variables.o rcpthosts.o control.o qmail.o \
-buffer_defs.h received.o auto_control.o auto_qmail.o auto_prefix.o
+received.o auto_control.o auto_qmail.o auto_prefix.o
 	./load mini-smtpd ipme.o socket_v6any.o socket_v4mappedprefix.o \
 	ipalloc.o ip.o variables.o rcpthosts.o control.o qmail.o \
 	received.o auto_qmail.o auto_control.o auto_prefix.o \
@@ -2109,7 +2107,7 @@ qreceipt.1: qreceipt.9 conf-sysconfdir
 
 qreceipt.o: \
 compile qreceipt.c hfield.h \
-headerbody.h quote.h qmail.h set_environment.h buffer_defs.h
+headerbody.h quote.h qmail.h set_environment.h
 	./compile qreceipt.c
 
 qsmhook: \
@@ -2144,7 +2142,7 @@ compile readsubdir.c readsubdir.h auto_split.h
 	./compile readsubdir.c
 
 received.o: \
-compile received.c qmail.h received.h buffer_defs.h
+compile received.c qmail.h received.h
 	./compile received.c
 
 remoteinfo.o: \
@@ -2164,7 +2162,7 @@ rrforward.1: rrforward.9 conf-sysconfdir
 	> rrforward.1
 
 rrforward.o: \
-compile rrforward.c qmail.h set_environment.h buffer_defs.h
+compile rrforward.c qmail.h set_environment.h
 	./compile rrforward.c
 
 sendmail: \
@@ -2398,7 +2396,7 @@ auto_prefix.o auto_control.o variables.o srs.lib
 	-L../libsrs2-x/libsrs2/.libs `cat srs.lib` $(QMAILLIB)
 
 srsfilter.o: \
-compile srsfilter.c qmail.h srs.h hassrs.h buffer_defs.h
+compile srsfilter.c qmail.h srs.h hassrs.h
 	./compile srsfilter.c
 
 strsalloc.o: \
@@ -2497,7 +2495,7 @@ load qbase64.o
 	./load qbase64 $(QMAILLIB)
 
 qbase64.o: \
-compile qbase64.c buffer_defs.h
+compile qbase64.c
 	./compile qbase64.c
 
 maildirdeliver: load maildirdeliver.o maildir_deliver.o \
@@ -2605,8 +2603,7 @@ checkdomain: load checkdomain.o
 checkdomain.o: compile checkdomain.c buffer_defs.h
 	./compile checkdomain.c
 
-filterto.o: compile filterto.c qmail.h set_environment.h \
-buffer_defs.h
+filterto.o: compile filterto.c qmail.h set_environment.h
 	./compile filterto.c
 
 filterto: load filterto.o qmail.o auto_prefix.o \
@@ -2686,7 +2683,7 @@ maildirserial.1: maildirserial.9 conf-sysconfdir
 
 maildirserial.o: \
 compile maildirserial.c prioq.h variables.h qmail.h \
-auto_control.h buffer_defs.h set_environment.h conf-mime
+auto_control.h set_environment.h conf-mime
 	./compile `grep -h -v "^#" conf-mime` maildirserial.c
 
 serialcmd: load serialcmd.o quote.o
@@ -3109,8 +3106,7 @@ new-inject.1: new-inject.9 conf-sysconfdir
 	> new-inject.1
 
 new-inject.o: \
-compile new-inject.c qmail.h buffer_defs.h \
-rwhconfig.h set_environment.h
+compile new-inject.c qmail.h rwhconfig.h set_environment.h
 	./compile new-inject.c
 
 822date: load 822date.o
@@ -3292,7 +3288,7 @@ sortedtest: load sortedtest.o sorted.o
 sortedtest.o: compile sortedtest.c sorted.h
 	./compile sortedtest.c
 
-generic.o: compile generic.c buffer_defs.h qmail.h
+generic.o: compile generic.c qmail.h
 	./compile generic.c
 
 relaytest.o: compile relaytest.c

--- a/indimail-mta-x/autoresponder.c
+++ b/indimail-mta-x/autoresponder.c
@@ -58,6 +58,7 @@
 #include "control.h"
 #include "auto_sysconfdir.h"
 #include "auto_prefix.h"
+#include "buffer_defs.h"
 
 #define strcasecmp(x,y)    case_diffs((x), (y))
 #define strncasecmp(x,y,z) case_diffb((x), (z), (y))
@@ -70,7 +71,7 @@ unsigned long   opt_maxmsgs = 1;
 time_t          when, opt_timelimit = 86400 * 7; /*- RFC 3834 */
 static char    *opt_subject_prefix = "Autoreply: Re: ";
 static char    *argv0, *dtline, *recipient, *from_addr = 0;
-static char     ssinbuf[512], ssoutbuf[512];
+static char     ssinbuf[BUFSIZE_IN], ssoutbuf[BUFSIZE_OUT];
 static char     strnum[FMT_ULONG];
 substdio        ssin, ssout;
 static pid_t    inject_pid;

--- a/indimail-mta-x/autoresponder.c
+++ b/indimail-mta-x/autoresponder.c
@@ -1,5 +1,5 @@
 /*
- * $Id: autoresponder.c,v 1.40 2023-10-25 13:25:55+05:30 Cprogrammer Exp mbhangui $
+ * $Id: autoresponder.c,v 1.41 2024-01-23 01:20:28+05:30 Cprogrammer Exp mbhangui $
  *
  * This is a simple program to automatically respond to emails.
  *
@@ -1248,7 +1248,7 @@ main(int argc, char *argv[])
 void
 getversion_qmail_autoresponder_c()
 {
-	static char    *x = "$Id: autoresponder.c,v 1.40 2023-10-25 13:25:55+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: autoresponder.c,v 1.41 2024-01-23 01:20:28+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 	x = sccsidmktempfileh;
@@ -1257,6 +1257,9 @@ getversion_qmail_autoresponder_c()
 
 /*
  * $Log: autoresponder.c,v $
+ * Revision 1.41  2024-01-23 01:20:28+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.40  2023-10-25 13:25:55+05:30  Cprogrammer
  * rewind descriptor 0 regardless of MAKE_SEEKABLE setting
  *

--- a/indimail-mta-x/buffer_defs.h
+++ b/indimail-mta-x/buffer_defs.h
@@ -1,0 +1,27 @@
+/*
+ * $Id: $
+ */
+#ifndef BUFFER_DEFS_H
+#define BUFFER_DEFS_H
+
+#ifndef BUFSIZE_MESS
+#define BUFSIZE_MESS   8192
+#endif
+
+#ifndef BUFSIZE_REMOTE
+#define BUFSIZE_REMOTE 4096
+#endif
+
+#ifndef BUFSIZE_IN
+#define BUFSIZE_IN     1024
+#endif
+
+#ifndef BUFSIZE_SMALL
+#define BUFSIZE_SMALL  128
+#endif
+
+#ifndef BUFSIZE_OUT
+#define BUFSIZE_OUT    512
+#endif
+
+#endif

--- a/indimail-mta-x/checkaddr.c
+++ b/indimail-mta-x/checkaddr.c
@@ -1,5 +1,8 @@
 /*
  * $Log: checkaddr.c,v $
+ * Revision 1.5  2024-01-23 01:24:00+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.4  2021-08-29 23:27:08+05:30  Cprogrammer
  * define functions as noreturn
  *
@@ -75,7 +78,7 @@ main(int argc, char **argv)
 void
 getversion_checkaddr_c()
 {
-	static char    *x = "$Id: checkaddr.c,v 1.4 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: checkaddr.c,v 1.5 2024-01-23 01:24:00+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/checkaddr.c
+++ b/indimail-mta-x/checkaddr.c
@@ -21,6 +21,7 @@
 #include <case.h>
 #include <env.h>
 #include <noreturn.h>
+#include "buffer_defs.h"
 
 #define FATAL "checkaddr: fatal: "
 
@@ -52,7 +53,7 @@ main(int argc, char **argv)
 {
 	stralloc        addrlist = { 0 };
 	int             match;
-	char            ssinbuf[1024];
+	char            ssinbuf[BUFSIZE_IN];
 	substdio        ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
 
 	recipient = env_get("RECIPIENT");

--- a/indimail-mta-x/checkdomain.c
+++ b/indimail-mta-x/checkdomain.c
@@ -1,5 +1,8 @@
 /*
  * $Log: checkdomain.c,v $
+ * Revision 1.5  2024-01-23 01:20:40+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.4  2021-08-29 23:27:08+05:30  Cprogrammer
  * define functions as noreturn
  *
@@ -83,7 +86,7 @@ main(int argc, char **argv)
 void
 getversion_checkdomain_c()
 {
-	static char    *x = "$Id: checkdomain.c,v 1.4 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: checkdomain.c,v 1.5 2024-01-23 01:20:40+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/checkdomain.c
+++ b/indimail-mta-x/checkdomain.c
@@ -22,6 +22,7 @@
 #include <case.h>
 #include <env.h>
 #include <noreturn.h>
+#include <buffer_defs.h>
 
 #define FATAL "checkdomain: fatal: "
 
@@ -53,7 +54,7 @@ main(int argc, char **argv)
 {
 	int             i, match;
 	stralloc        addrlist = { 0 };
-	char            ssinbuf[1024];
+	char            ssinbuf[BUFSIZE_IN];
 	substdio        ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
 
 	recipient = env_get("RECIPIENT");

--- a/indimail-mta-x/checkdomain.c
+++ b/indimail-mta-x/checkdomain.c
@@ -22,7 +22,7 @@
 #include <case.h>
 #include <env.h>
 #include <noreturn.h>
-#include <buffer_defs.h>
+#include "buffer_defs.h"
 
 #define FATAL "checkdomain: fatal: "
 

--- a/indimail-mta-x/doc/ChangeLog
+++ b/indimail-mta-x/doc/ChangeLog
@@ -34,12 +34,14 @@ Release @version@-@release@ Start 02/01/2024 End XX/XX/XXXX
 17. smtpd.c: prepend '@' to helohost when doing dnscheck
 - 17/01/2024
 18. svctool.in: fixed permissions of /run/indimail/pwdlookup
-- 29/01/2024
+- 19/01/2024
 19. qmail.h: increased qmail-queue buffer to 8192 for performance
     (qmail-queue)
 20. smtpd.c: fixed logerr() cloberring strnum
 21. use env variable ALLOW_BARELF to allow bare LF from smtp clients without
     SMTP smuggling
+- 23/01/2024
+22. include buffer_defs.h for buffer size definitions
 
 * Mon Jan 01 2024 18:55:50 +0000 Manvendra Bhangui <indimail-mta@indimail.org> 3.0.6-1.1%{?dist}
 Release 3.0.6-1.1 Start 25/10/2023 End 01/01/2024

--- a/indimail-mta-x/dot-forward.c
+++ b/indimail-mta-x/dot-forward.c
@@ -1,5 +1,8 @@
 /*
  * $Log: dot-forward.c,v $
+ * Revision 1.17  2024-01-23 01:24:06+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.16  2021-08-29 23:27:08+05:30  Cprogrammer
  * define functions as noreturn
  *
@@ -522,7 +525,7 @@ main(argc, argv)
 void
 getversion_dot_forward_c()
 {
-	static char    *x = "$Id: dot-forward.c,v 1.16 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: dot-forward.c,v 1.17 2024-01-23 01:24:06+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/dot-forward.c
+++ b/indimail-mta-x/dot-forward.c
@@ -72,6 +72,7 @@
 #include "control.h"
 #include "qmail.h"
 #include "set_environment.h"
+#include "buffer_defs.h"
 
 #define FATAL "dot-forward: fatal: "
 #define WARN  "dot-forward: warn: "
@@ -108,9 +109,9 @@ struct qmail    qq;
 unsigned long   qp;
 char           *qqx;
 char            strnum[FMT_ULONG];
-char            qqbuf[256];
+char            qqbuf[BUFSIZE_OUT];
 substdio        ssqq = SUBSTDIO_FDBUF(mywrite, -1, qqbuf, sizeof qqbuf);
-char            inbuf[256];
+char            inbuf[BUFSIZE_IN];
 
 no_return void
 die_nomem()

--- a/indimail-mta-x/fastforward.c
+++ b/indimail-mta-x/fastforward.c
@@ -67,6 +67,7 @@
 #include "strset.h"
 #include "slurpclose.h"
 #include "set_environment.h"
+#include "buffer_defs.h"
 
 #define FATAL "fastforward: fatal: "
 #define WARN  "fastforward: warn: "
@@ -116,7 +117,7 @@ qqwrite(int fd, char *buf, int len)
 }
 
 substdio        ssqq = SUBSTDIO_FDBUF(qqwrite, -1, qqbuf, sizeof qqbuf);
-char            messbuf[4096];
+char            messbuf[BUFSIZE_REMOTE];
 substdio        ssmess = SUBSTDIO_FDBUF(read, 0, messbuf, sizeof messbuf);
 int             flagdeliver = 1;
 int             flagpassthrough = 0;

--- a/indimail-mta-x/fastforward.c
+++ b/indimail-mta-x/fastforward.c
@@ -1,5 +1,5 @@
 /*
- * $Id: $
+ * $Id: fastforward.c,v 1.14 2024-01-23 01:26:53+05:30 Cprogrammer Exp mbhangui $
  */
 #include <unistd.h>
 #include <sys/types.h>
@@ -427,13 +427,16 @@ main(int argc, char **argv)
 void
 getversion_fastforward_c()
 {
-	static char    *x = "$Id: fastforward.c,v 1.13 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: fastforward.c,v 1.14 2024-01-23 01:26:53+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }
 
 /*
  * $Log: fastforward.c,v $
+ * Revision 1.14  2024-01-23 01:26:53+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.13  2021-08-29 23:27:08+05:30  Cprogrammer
  * define functions as noreturn
  *

--- a/indimail-mta-x/fastforward.c
+++ b/indimail-mta-x/fastforward.c
@@ -1,44 +1,5 @@
 /*
- * $Log: fastforward.c,v $
- * Revision 1.13  2021-08-29 23:27:08+05:30  Cprogrammer
- * define functions as noreturn
- *
- * Revision 1.12  2021-07-05 21:10:17+05:30  Cprogrammer
- * skip $HOME/.defaultqueue for root
- *
- * Revision 1.11  2021-05-13 14:43:09+05:30  Cprogrammer
- * use set_environment() to set env from ~/.defaultqueue or control/defaultqueue
- *
- * Revision 1.10  2020-11-24 13:45:14+05:30  Cprogrammer
- * removed exit.h
- *
- * Revision 1.9  2020-04-04 11:41:41+05:30  Cprogrammer
- * use auto_sysconfdir instead of auto_qmail
- *
- * Revision 1.8  2020-04-04 11:17:10+05:30  Cprogrammer
- * use environment variables $HOME/.defaultqueue before /etc/indimail/control/defaultqueue
- *
- * Revision 1.7  2019-06-07 11:26:18+05:30  Cprogrammer
- * replaced getopt() with subgetopt()
- *
- * Revision 1.6  2016-05-17 19:44:58+05:30  Cprogrammer
- * use auto_control, set by conf-control to set control directory
- *
- * Revision 1.5  2010-06-08 21:59:13+05:30  Cprogrammer
- * use envdir_set() on queuedefault to set default queue parameters
- *
- * Revision 1.4  2008-07-15 19:51:02+05:30  Cprogrammer
- * porting for Mac OS X
- *
- * Revision 1.3  2004-10-22 20:25:01+05:30  Cprogrammer
- * added RCS id
- *
- * Revision 1.2  2004-10-22 15:35:04+05:30  Cprogrammer
- * removed readwrite.h
- *
- * Revision 1.1  2004-10-21 22:46:37+05:30  Cprogrammer
- * Initial revision
- *
+ * $Id: $
  */
 #include <unistd.h>
 #include <sys/types.h>
@@ -71,6 +32,18 @@
 
 #define FATAL "fastforward: fatal: "
 #define WARN  "fastforward: warn: "
+
+ssize_t         qqwrite(int, char *, int);
+
+struct qmail    qq;
+char            qp[FMT_ULONG], qqbuf[1], messbuf[BUFSIZE_REMOTE];
+substdio        ssqq = SUBSTDIO_FDBUF(qqwrite, -1, qqbuf, sizeof qqbuf);
+substdio        ssmess = SUBSTDIO_FDBUF(read, 0, messbuf, sizeof messbuf);
+int             flagdeliver = 1, flagpassthrough = 0, fdcdb, flagdefault = 0;
+char           *dtline, *fncdb;
+stralloc        sender, programs, forward, todo, mailinglist, key, data, recipient;
+strset          done;
+uint32          dlen;
 
 no_return void
 usage()
@@ -105,10 +78,6 @@ printsafe(char *s)
 	}
 }
 
-struct qmail    qq;
-char            qp[FMT_ULONG];
-char            qqbuf[1];
-
 ssize_t
 qqwrite(int fd, char *buf, int len)
 {
@@ -116,26 +85,11 @@ qqwrite(int fd, char *buf, int len)
 	return len;
 }
 
-substdio        ssqq = SUBSTDIO_FDBUF(qqwrite, -1, qqbuf, sizeof qqbuf);
-char            messbuf[BUFSIZE_REMOTE];
-substdio        ssmess = SUBSTDIO_FDBUF(read, 0, messbuf, sizeof messbuf);
-int             flagdeliver = 1;
-int             flagpassthrough = 0;
-char           *dtline;
-stralloc        sender = { 0 };
-stralloc        programs = { 0 };
-stralloc        forward = { 0 };
-strset          done;
-stralloc        todo = { 0 };
-stralloc        mailinglist = { 0 };
-
 void
 dofile(char *fn)
 {
-	int             fd;
+	int             fd, i, j;
 	struct stat     st;
-	int             i;
-	int             j;
 
 	if (!stralloc_copys(&mailinglist, ""))
 		nomem();
@@ -147,31 +101,22 @@ dofile(char *fn)
 		strerr_die3x(111, FATAL, fn, " is not world-readable");
 	if (slurpclose(fd, &mailinglist, 1024) == -1)
 		strerr_die4sys(111, FATAL, "unable to read ", fn, ": ");
-	i = 0;
-	for (j = 0; j < mailinglist.len; ++j) {
+	for (i = j = 0; j < mailinglist.len; ++j) {
 		if (!mailinglist.s[j]) {
 			if ((mailinglist.s[i] == '.') || (mailinglist.s[i] == '/')) {
-				if (!stralloc_cats(&todo, mailinglist.s + i))
-					nomem();
-				if (!stralloc_0(&todo))
+				if (!stralloc_cats(&todo, mailinglist.s + i) ||
+						!stralloc_0(&todo))
 					nomem();
 			} else
 			if ((mailinglist.s[i] == '&') && (j - i < 900)) {
-				if (!stralloc_cats(&todo, mailinglist.s + i))
-					nomem();
-				if (!stralloc_0(&todo))
+				if (!stralloc_cats(&todo, mailinglist.s + i) ||
+						!stralloc_0(&todo))
 					nomem();
 			}
 			i = j + 1;
 		}
-	} /*- for (j = 0; j < mailinglist.len; ++j) */
+	} /*- for (i = j = 0; j < mailinglist.len; ++j) */
 }
-
-char           *fncdb;
-int             fdcdb;
-stralloc        key = { 0 };
-uint32          dlen;
-stralloc        data = { 0 };
 
 no_return void
 cdbreaderror()
@@ -182,12 +127,10 @@ cdbreaderror()
 int
 findtarget(int flagwild, char *prepend, char *addr)
 {
-	int             r;
-	int             at;
+	int             r, at;
 
-	if (!stralloc_copys(&key, prepend))
-		nomem();
-	if (!stralloc_cats(&key, addr))
+	if (!stralloc_copys(&key, prepend) ||
+			!stralloc_cats(&key, addr))
 		nomem();
 	case_lowerb(key.s, key.len);
 	if ((r = cdb_seek(fdcdb, key.s, key.len, &dlen)) == -1)
@@ -199,18 +142,16 @@ findtarget(int flagwild, char *prepend, char *addr)
 	at = str_rchr(addr, '@');
 	if (!addr[at])
 		return 0;
-	if (!stralloc_copys(&key, prepend))
-		nomem();
-	if (!stralloc_cats(&key, addr + at))
+	if (!stralloc_copys(&key, prepend) ||
+			!stralloc_cats(&key, addr + at))
 		nomem();
 	case_lowerb(key.s, key.len);
 	if ((r = cdb_seek(fdcdb, key.s, key.len, &dlen)) == -1)
 		cdbreaderror();
 	if (r)
 		return 1;
-	if (!stralloc_copys(&key, prepend))
-		nomem();
-	if (!stralloc_catb(&key, addr, at + 1))
+	if (!stralloc_copys(&key, prepend) ||
+			!stralloc_catb(&key, addr, at + 1))
 		nomem();
 	case_lowerb(key.s, key.len);
 	if ((r = cdb_seek(fdcdb, key.s, key.len, &dlen)) == -1)
@@ -237,8 +178,7 @@ void
 doprogram(char *arg)
 {
 	char           *args[5];
-	int             child;
-	int             wstat;
+	int             child, wstat;
 
 	if (!flagdeliver) {
 		print("run ");
@@ -294,8 +234,7 @@ doprogram(char *arg)
 void
 dodata()
 {
-	int             i;
-	int             j;
+	int             i, j;
 
 	i = 0;
 	for (j = 0; j < data.len; ++j) {
@@ -304,15 +243,13 @@ dodata()
 				doprogram(data.s + i);
 			else
 			if ((data.s[i] == '.') || (data.s[i] == '/')) {
-				if (!stralloc_cats(&todo, data.s + i))
-					nomem();
-				if (!stralloc_0(&todo))
+				if (!stralloc_cats(&todo, data.s + i) ||
+						!stralloc_0(&todo))
 					nomem();
 			} else
 			if ((data.s[i] == '&') && (j - i < 900)) {
-				if (!stralloc_cats(&todo, data.s + i))
-					nomem();
-				if (!stralloc_0(&todo))
+				if (!stralloc_cats(&todo, data.s + i) ||
+						!stralloc_0(&todo))
 					nomem();
 			}
 			i = j + 1;
@@ -328,9 +265,8 @@ dorecip(char *addr)
 		dodata();
 		return;
 	}
-	if (!stralloc_cats(&forward, addr))
-		nomem();
-	if (!stralloc_0(&forward))
+	if (!stralloc_cats(&forward, addr) ||
+			!stralloc_0(&forward))
 		nomem();
 }
 
@@ -352,9 +288,6 @@ doorigrecip(char *addr)
 	dodata();
 }
 
-stralloc        recipient = { 0 };
-int             flagdefault = 0;
-
 int
 main(int argc, char **argv)
 {
@@ -366,11 +299,9 @@ main(int argc, char **argv)
 		dtline = "";
 	if (!(x = env_get("SENDER")))
 		x = "original envelope sender";
-	if (!stralloc_copys(&sender, x))
-		nomem();
-	if (!stralloc_copys(&forward, ""))
-		nomem();
-	if (!strset_init(&done))
+	if (!stralloc_copys(&sender, x) ||
+			!stralloc_copys(&forward, "") ||
+			!strset_init(&done))
 		nomem();
 	while ((opt = getopt(argc, argv, "nNpPdD")) != opteof) {
 		switch (opt)
@@ -408,21 +339,18 @@ main(int argc, char **argv)
 			x = env_get("EXT");
 		if (!x)
 			strerr_die2x(100, FATAL, "$DEFAULT or $EXT must be set");
-		if (!stralloc_copys(&recipient, x))
-			nomem();
-		if (!stralloc_cats(&recipient, "@"))
+		if (!stralloc_copys(&recipient, x) ||
+				!stralloc_cats(&recipient, "@"))
 			nomem();
 		if (!(x = env_get("HOST")))
 			strerr_die2x(100, FATAL, "$HOST must be set");
-		if (!stralloc_cats(&recipient, x))
-			nomem();
-		if (!stralloc_0(&recipient))
+		if (!stralloc_cats(&recipient, x) ||
+				!stralloc_0(&recipient))
 			nomem();
 		x = recipient.s;
-	} else {
-		if (!(x = env_get("RECIPIENT")))
-			strerr_die2x(100, FATAL, "$RECIPIENT must be set");
-	}
+	} else
+	if (!(x = env_get("RECIPIENT")))
+		strerr_die2x(100, FATAL, "$RECIPIENT must be set");
 	if (!strset_add(&done, x))
 		nomem();
 	doorigrecip(x);
@@ -503,3 +431,46 @@ getversion_fastforward_c()
 
 	x++;
 }
+
+/*
+ * $Log: fastforward.c,v $
+ * Revision 1.13  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define functions as noreturn
+ *
+ * Revision 1.12  2021-07-05 21:10:17+05:30  Cprogrammer
+ * skip $HOME/.defaultqueue for root
+ *
+ * Revision 1.11  2021-05-13 14:43:09+05:30  Cprogrammer
+ * use set_environment() to set env from ~/.defaultqueue or control/defaultqueue
+ *
+ * Revision 1.10  2020-11-24 13:45:14+05:30  Cprogrammer
+ * removed exit.h
+ *
+ * Revision 1.9  2020-04-04 11:41:41+05:30  Cprogrammer
+ * use auto_sysconfdir instead of auto_qmail
+ *
+ * Revision 1.8  2020-04-04 11:17:10+05:30  Cprogrammer
+ * use environment variables $HOME/.defaultqueue before /etc/indimail/control/defaultqueue
+ *
+ * Revision 1.7  2019-06-07 11:26:18+05:30  Cprogrammer
+ * replaced getopt() with subgetopt()
+ *
+ * Revision 1.6  2016-05-17 19:44:58+05:30  Cprogrammer
+ * use auto_control, set by conf-control to set control directory
+ *
+ * Revision 1.5  2010-06-08 21:59:13+05:30  Cprogrammer
+ * use envdir_set() on queuedefault to set default queue parameters
+ *
+ * Revision 1.4  2008-07-15 19:51:02+05:30  Cprogrammer
+ * porting for Mac OS X
+ *
+ * Revision 1.3  2004-10-22 20:25:01+05:30  Cprogrammer
+ * added RCS id
+ *
+ * Revision 1.2  2004-10-22 15:35:04+05:30  Cprogrammer
+ * removed readwrite.h
+ *
+ * Revision 1.1  2004-10-21 22:46:37+05:30  Cprogrammer
+ * Initial revision
+ *
+ */

--- a/indimail-mta-x/filterit_sub.c
+++ b/indimail-mta-x/filterit_sub.c
@@ -34,6 +34,7 @@
 #endif
 #include <sig.h>
 #include <fmt.h>
+#include <buffer_defs.h>
 #include "qmail.h"
 #include "set_environment.h"
 #include "filterit.h"
@@ -401,7 +402,7 @@ filterit_sub1(int argc, char **argv)
 						"Numerical Logical Expression", "RegExp", 0
 					};
 	char           *act[] = {"exit", "forward", "maildir", 0};
-	char            ssinbuf[1024], ssoutbuf[512];
+	char            ssinbuf[BUFSIZE_IN], ssoutbuf[BUFSIZE_OUT];
 	int             opt, i, match, negate = 0, keep_continue = 0, 
 					c_opt = 0, a_opt = 0, default_a_opt = 0, in_header;
 	substdio        ssin, ssout;

--- a/indimail-mta-x/filterit_sub.c
+++ b/indimail-mta-x/filterit_sub.c
@@ -34,7 +34,7 @@
 #endif
 #include <sig.h>
 #include <fmt.h>
-#include <buffer_defs.h>
+#include "buffer_defs.h"
 #include "qmail.h"
 #include "set_environment.h"
 #include "filterit.h"

--- a/indimail-mta-x/filterit_sub.c
+++ b/indimail-mta-x/filterit_sub.c
@@ -1,5 +1,5 @@
 /*
- * $Id: filterit_sub.c,v 1.6 2024-01-10 22:57:31+05:30 Cprogrammer Exp mbhangui $
+ * $Id: filterit_sub.c,v 1.7 2024-01-23 01:20:57+05:30 Cprogrammer Exp mbhangui $
  */
 #include <ctype.h>
 #include <unistd.h>
@@ -655,6 +655,9 @@ getversion_filterit_c()
 
 /*
  * $Log: filterit_sub.c,v $
+ * Revision 1.7  2024-01-23 01:20:57+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.6  2024-01-10 22:57:31+05:30  Cprogrammer
  * reset sgoptpost for repeated calls to subgetopt
  *

--- a/indimail-mta-x/filterto.c
+++ b/indimail-mta-x/filterto.c
@@ -63,10 +63,7 @@ void        (*sig_ignorehandler)() = SIG_IGN;
 struct qmail    qqt;
 
 ssize_t
-mywrite(fd, buf, len)
-	int             fd;
-	char           *buf;
-	int             len;
+mywrite(int fd, char *buf, int len)
 {
 	qmail_put(&qqt, buf, len);
 	return len;

--- a/indimail-mta-x/filterto.c
+++ b/indimail-mta-x/filterto.c
@@ -1,5 +1,8 @@
 /*
  * $Log: filterto.c,v $
+ * Revision 1.13  2024-01-23 01:21:12+05:30  Cprogrammer
+ * convert mywrite to ansic prototype
+ *
  * Revision 1.12  2021-07-05 21:10:21+05:30  Cprogrammer
  * skip $HOME/.defaultqueue for root
  *
@@ -143,7 +146,7 @@ main(int argc, char **argv, char **envp)
 void
 getversion_filterto_c()
 {
-	static char    *x = "$Id: filterto.c,v 1.12 2021-07-05 21:10:21+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: filterto.c,v 1.13 2024-01-23 01:21:12+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/ifaddr.c
+++ b/indimail-mta-x/ifaddr.c
@@ -23,7 +23,7 @@
 #include <case.h>
 #include <env.h>
 #include <noreturn.h>
-#include <buffer_defs.h>
+#include "buffer_defs.h"
 
 #define FATAL "ifaddr: fatal: "
 

--- a/indimail-mta-x/ifaddr.c
+++ b/indimail-mta-x/ifaddr.c
@@ -23,6 +23,7 @@
 #include <case.h>
 #include <env.h>
 #include <noreturn.h>
+#include <buffer_defs.h>
 
 #define FATAL "ifaddr: fatal: "
 
@@ -99,7 +100,7 @@ main(int argc, char **argv)
 {
 	int             i, j, match;
 	stralloc        line = { 0 };
-	char            ssinbuf[1024];
+	char            ssinbuf[BUFSIZE_IN];
 	substdio        ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
 	mess822_header  h = MESS822_HEADER;
 	mess822_action *a;

--- a/indimail-mta-x/ifaddr.c
+++ b/indimail-mta-x/ifaddr.c
@@ -1,5 +1,8 @@
 /*
  * $Log: ifaddr.c,v $
+ * Revision 1.5  2024-01-23 01:21:26+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.4  2021-08-29 23:27:08+05:30  Cprogrammer
  * define functions as noreturn
  *
@@ -152,7 +155,7 @@ main(int argc, char **argv)
 void
 getversion_ifaddr_c()
 {
-	static char    *x = "$Id: ifaddr.c,v 1.4 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: ifaddr.c,v 1.5 2024-01-23 01:21:26+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/iftoccfrom.c
+++ b/indimail-mta-x/iftoccfrom.c
@@ -1,5 +1,8 @@
 /*
  * $Log: iftoccfrom.c,v $
+ * Revision 1.5  2024-01-23 01:24:13+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.4  2021-08-29 23:27:08+05:30  Cprogrammer
  * define functions as noreturn
  *
@@ -98,7 +101,7 @@ main(int argc, char **argv)
 void
 getversion_iftoccfrom_c()
 {
-	static char    *x = "$Id: iftoccfrom.c,v 1.4 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: iftoccfrom.c,v 1.5 2024-01-23 01:24:13+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/iftoccfrom.c
+++ b/indimail-mta-x/iftoccfrom.c
@@ -36,8 +36,7 @@ char           *recipient;
 char          **recips;
 
 void
-check(addr)
-	char           *addr;
+check(char *addr)
 {
 	int             i;
 
@@ -52,9 +51,7 @@ check(addr)
 }
 
 int
-main(argc, argv)
-	int             argc;
-	char          **argv;
+main(int argc, char **argv)
 {
 	int             i, j, match;
 	stralloc        addrlist = { 0 }, line = { 0 };

--- a/indimail-mta-x/iftoccfrom.c
+++ b/indimail-mta-x/iftoccfrom.c
@@ -21,7 +21,7 @@
 #include <case.h>
 #include <env.h>
 #include <noreturn.h>
-#include <buffer_defs.h>
+#include "buffer_defs.h"
 
 #define FATAL "iftoccfrom: fatal: "
 

--- a/indimail-mta-x/iftoccfrom.c
+++ b/indimail-mta-x/iftoccfrom.c
@@ -21,6 +21,7 @@
 #include <case.h>
 #include <env.h>
 #include <noreturn.h>
+#include <buffer_defs.h>
 
 #define FATAL "iftoccfrom: fatal: "
 
@@ -57,7 +58,7 @@ main(argc, argv)
 {
 	int             i, j, match;
 	stralloc        addrlist = { 0 }, line = { 0 };
-	char            ssinbuf[1024];
+	char            ssinbuf[BUFSIZE_IN];
 	substdio        ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
 	mess822_header  h = MESS822_HEADER;
 	mess822_action  a[] = {

--- a/indimail-mta-x/mini-smtpd.c
+++ b/indimail-mta-x/mini-smtpd.c
@@ -26,6 +26,7 @@
 #include "ip.h"
 #include "qmail.h"
 #include "rcpthosts.h"
+#include "buffer_defs.h"
 
 #define MAXHOPS 100
 static int      databytes = 0;
@@ -36,7 +37,7 @@ static int      flagsize = 0;
 static stralloc greeting = { 0 };
 static stralloc helohost = { 0 };
 static stralloc liphost = { 0 };
-static stralloc addr = { 0 };	/* will be 0-terminated, if addrparse returns 1 */
+static stralloc addr = { 0 }; /* will be 0-terminated, if addrparse returns 1 */
 static stralloc mailfrom = { 0 };
 static stralloc rcptto = { 0 };
 static stralloc mfparms = { 0 };
@@ -45,9 +46,9 @@ static char    *remotehost;
 static char    *remoteinfo;
 static char    *local;
 static char    *relayclient;
-static char    *fakehelo;		/* pointer into helohost, or 0 */
-static char     ssinbuf[1024];
-static char     ssoutbuf[512];
+static char    *fakehelo; /* pointer into helohost, or 0 */
+static char     ssinbuf[BUFSIZE_IN];
+static char     ssoutbuf[BUFSIZE_OUT];
 static ssize_t  safewrite(int, char *, size_t);
 static ssize_t  saferead(int, char *, size_t);
 static substdio ssin = SUBSTDIO_FDBUF(saferead, 0, ssinbuf, sizeof ssinbuf);

--- a/indimail-mta-x/mini-smtpd.c
+++ b/indimail-mta-x/mini-smtpd.c
@@ -1,5 +1,5 @@
 /*
- * $Id: mini-smtpd.c,v 1.8 2024-01-20 23:38:37+05:30 Cprogrammer Exp mbhangui $
+ * $Id: mini-smtpd.c,v 1.9 2024-01-23 01:21:56+05:30 Cprogrammer Exp mbhangui $
  */
 #include <unistd.h>
 #include <sig.h>
@@ -718,13 +718,16 @@ main(int argc, char **argv)
 void
 getversion_mini_smtpd()
 {
-	static char    *x = "$Id: mini-smtpd.c,v 1.8 2024-01-20 23:38:37+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: mini-smtpd.c,v 1.9 2024-01-23 01:21:56+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }
 
 /*
  * $Log: mini-smtpd.c,v $
+ * Revision 1.9  2024-01-23 01:21:56+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.8  2024-01-20 23:38:37+05:30  Cprogrammer
  * use env variable ALLOW_BARELF to allow bare LF from smtp clients
  *

--- a/indimail-mta-x/ofmipd.c
+++ b/indimail-mta-x/ofmipd.c
@@ -102,6 +102,7 @@
 #include <commands.h>
 #include <strerr.h>
 #include <noreturn.h>
+#include <buffer_defs.h>
 #include "rwhconfig.h"
 #include "qmail.h"
 #include "control.h"
@@ -141,7 +142,7 @@ static stralloc resp = { 0 };
 static stralloc slop = { 0 };
 static stralloc line = { 0 };
 static unsigned int    databytes = 0;
-static char     ssinbuf[1024], ssoutbuf[512], sserrbuf[512];
+static char     ssinbuf[BUFSIZE_IN], ssoutbuf[BUFSIZE_OUT], sserrbuf[BUFSIZE_OUT];
 static substdio ssin = SUBSTDIO_FDBUF(saferead, 0, ssinbuf, sizeof ssinbuf);
 static substdio ssout = SUBSTDIO_FDBUF(safewrite, 1, ssoutbuf, sizeof ssoutbuf);
 static substdio sserr = SUBSTDIO_FDBUF(safewrite, 2, sserrbuf, sizeof sserrbuf);

--- a/indimail-mta-x/ofmipd.c
+++ b/indimail-mta-x/ofmipd.c
@@ -1,5 +1,8 @@
 /*
  * $Log: ofmipd.c,v $
+ * Revision 1.25  2024-01-23 01:22:02+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.24  2023-01-03 16:38:44+05:30  Cprogrammer
  * removed auto_sysconfdir.h dependency
  *
@@ -1243,7 +1246,7 @@ main(int argc, char **argv)
 void
 getversion_ofmipd_c()
 {
-	static char    *x = "$Id: ofmipd.c,v 1.24 2023-01-03 16:38:44+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: ofmipd.c,v 1.25 2024-01-23 01:22:02+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/ofmipd.c
+++ b/indimail-mta-x/ofmipd.c
@@ -102,7 +102,7 @@
 #include <commands.h>
 #include <strerr.h>
 #include <noreturn.h>
-#include <buffer_defs.h>
+#include "buffer_defs.h"
 #include "rwhconfig.h"
 #include "qmail.h"
 #include "control.h"

--- a/indimail-mta-x/qaes.c
+++ b/indimail-mta-x/qaes.c
@@ -41,7 +41,7 @@
 #include <error.h>
 #include <strerr.h>
 #include <noreturn.h>
-#include <buffer_defs.h>
+#include "buffer_defs.h"
 
 #define READ_ERR  1
 #define WRITE_ERR 2

--- a/indimail-mta-x/qaes.c
+++ b/indimail-mta-x/qaes.c
@@ -41,6 +41,7 @@
 #include <error.h>
 #include <strerr.h>
 #include <noreturn.h>
+#include <buffer_defs.h>
 
 #define READ_ERR  1
 #define WRITE_ERR 2
@@ -48,9 +49,9 @@
 #define USAGE_ERR 4
 #define AES_BLOCK_SIZE 512
 
-static char     ssinbuf[1024];
-static char     ssoutbuf[512];
-static char     sserrbuf[512];
+static char     ssinbuf[BUFSIZE_IN];
+static char     ssoutbuf[BUFSIZE_OUT];
+static char     sserrbuf[BUFSIZE_OUT];
 static char    *usage = "usage: qaes -k key [ -i -d -e -s salt ]\n";
 static char     strnum[FMT_ULONG];
 static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);

--- a/indimail-mta-x/qaes.c
+++ b/indimail-mta-x/qaes.c
@@ -7,6 +7,9 @@
  * Saju Pillai (saju.pillai@gmail.com)
  *
  * $Log: qaes.c,v $
+ * Revision 1.7  2024-01-23 01:24:18+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.6  2021-08-29 23:27:08+05:30  Cprogrammer
  * define functions as noreturn
  *
@@ -344,7 +347,7 @@ main(int argc, char **argv)
 void
 getversion_qaes_c()
 {
-	static char    *x = "$Id: qaes.c,v 1.6 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qaes.c,v 1.7 2024-01-23 01:24:18+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qarf.c
+++ b/indimail-mta-x/qarf.c
@@ -56,7 +56,7 @@
 #include <error.h>
 #include <sgetopt.h>
 #include <noreturn.h>
-#include <buffer_defs.h>
+#include "buffer_defs.h"
 
 #define READ_ERR  1
 #define WRITE_ERR 2

--- a/indimail-mta-x/qarf.c
+++ b/indimail-mta-x/qarf.c
@@ -56,6 +56,7 @@
 #include <error.h>
 #include <sgetopt.h>
 #include <noreturn.h>
+#include <buffer_defs.h>
 
 #define READ_ERR  1
 #define WRITE_ERR 2
@@ -65,8 +66,8 @@
 #define LSEEK_ERR 6
 #define USAGE_ERR 7
 
-static char     ssoutbuf[512];
-static char     sserrbuf[512];
+static char     ssoutbuf[BUFSIZE_OUT];
+static char     sserrbuf[BUFSIZE_OUT];
 static char     strnum[FMT_ULONG];
 static char    *usage = "usage: qarf [-i] -t recipient -s subject -f sender [-m filename]\n";
 static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);

--- a/indimail-mta-x/qarf.c
+++ b/indimail-mta-x/qarf.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qarf.c,v $
+ * Revision 1.14  2024-01-23 01:22:15+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.13  2021-08-29 23:27:08+05:30  Cprogrammer
  * define functions as noreturn
  *
@@ -417,7 +420,7 @@ main(int argc, char **argv)
 	my_putb("\"; ", 3);
 	my_puts(
 			"report-type=\"feedback-report\"\n"
-			"X-Mailer: qarf $Revision: 1.13 $\n");
+			"X-Mailer: qarf $Revision: 1.14 $\n");
 
 	/*- Body */
 	my_puts("\nThis is a multi-part message in MIME format\n\n");
@@ -461,7 +464,7 @@ main(int argc, char **argv)
 
 	my_puts(
 			"Feedback-Type: abuse\n"
-			"User-Agent: $Id: qarf.c,v 1.13 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $\n"
+			"User-Agent: $Id: qarf.c,v 1.14 2024-01-23 01:22:15+05:30 Cprogrammer Exp mbhangui $\n"
 			"Version: 0.1\n");
 	if (email_from.len) {
 		my_putb("Original-Mail-From: ", 20);
@@ -521,7 +524,7 @@ main(int argc, char **argv)
 void
 getversion_qarf_c()
 {
-	static char    *x = "$Id: qarf.c,v 1.13 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qarf.c,v 1.14 2024-01-23 01:22:15+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qbase64.c
+++ b/indimail-mta-x/qbase64.c
@@ -23,10 +23,11 @@
 #include <sgetopt.h>
 #include <error.h>
 #include <noreturn.h>
+#include <buffer_defs.h>
 
-static char     ssinbuf[1024];
-static char     ssoutbuf[512];
-static char     sserrbuf[512];
+static char     ssinbuf[BUFSIZE_IN];
+static char     ssoutbuf[BUFSIZE_OUT];
+static char     sserrbuf[BUFSIZE_OUT];
 static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
 static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
 static substdio sserr = SUBSTDIO_FDBUF(write, 2, sserrbuf, sizeof(sserrbuf));

--- a/indimail-mta-x/qbase64.c
+++ b/indimail-mta-x/qbase64.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qbase64.c,v $
+ * Revision 1.9  2024-01-23 01:22:20+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.8  2021-08-29 23:27:08+05:30  Cprogrammer
  * define functions as noreturn
  *
@@ -103,7 +106,7 @@ main(int argc, char **argv)
 void
 getversion_qbase64_c()
 {
-	static char    *x = "$Id: qbase64.c,v 1.8 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qbase64.c,v 1.9 2024-01-23 01:22:20+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qbase64.c
+++ b/indimail-mta-x/qbase64.c
@@ -23,7 +23,7 @@
 #include <sgetopt.h>
 #include <error.h>
 #include <noreturn.h>
-#include <buffer_defs.h>
+#include "buffer_defs.h"
 
 static char     ssinbuf[BUFSIZE_IN];
 static char     ssoutbuf[BUFSIZE_OUT];

--- a/indimail-mta-x/qmail-cat.c
+++ b/indimail-mta-x/qmail-cat.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-cat.c,v $
+ * Revision 1.10  2024-01-23 01:24:23+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.9  2021-10-20 23:30:20+05:30  Cprogrammer
  * added SIGTERM handler to flush io
  *
@@ -136,7 +139,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_cat_c()
 {
-	static char    *x = "$Id: qmail-cat.c,v 1.9 2021-10-20 23:30:20+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-cat.c,v 1.10 2024-01-23 01:24:23+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qmail-cat.c
+++ b/indimail-mta-x/qmail-cat.c
@@ -39,10 +39,11 @@
 #include <error.h>
 #include <sig.h>
 #include <noreturn.h>
+#include <buffer_defs.h>
 
-static char     ssinbuf[1024];
-static char     ssoutbuf[512];
-static char     sserrbuf[512];
+static char     ssinbuf[BUFSIZE_IN];
+static char     ssoutbuf[BUFSIZE_OUT];
+static char     sserrbuf[BUFSIZE_OUT];
 static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
 static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
 static substdio sserr = SUBSTDIO_FDBUF(write, 2, sserrbuf, sizeof(sserrbuf));

--- a/indimail-mta-x/qmail-cat.c
+++ b/indimail-mta-x/qmail-cat.c
@@ -39,7 +39,7 @@
 #include <error.h>
 #include <sig.h>
 #include <noreturn.h>
-#include <buffer_defs.h>
+#include "buffer_defs.h"
 
 static char     ssinbuf[BUFSIZE_IN];
 static char     ssoutbuf[BUFSIZE_OUT];

--- a/indimail-mta-x/qmail-dkim.c
+++ b/indimail-mta-x/qmail-dkim.c
@@ -1,5 +1,5 @@
 /*
- * $Id: qmail-dkim.c,v 1.81 2024-01-10 23:01:23+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-dkim.c,v 1.82 2024-01-23 01:22:34+05:30 Cprogrammer Exp mbhangui $
  */
 #include "hasdkim.h"
 #ifdef HASDKIM
@@ -1298,7 +1298,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_dkim_c()
 {
-	static char    *x = "$Id: qmail-dkim.c,v 1.81 2024-01-10 23:01:23+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-dkim.c,v 1.82 2024-01-23 01:22:34+05:30 Cprogrammer Exp mbhangui $";
 
 #ifdef HASDKIM
 	x = sccsidmakeargsh;
@@ -1312,6 +1312,9 @@ getversion_qmail_dkim_c()
 
 /*
  * $Log: qmail-dkim.c,v $
+ * Revision 1.82  2024-01-23 01:22:34+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.81  2024-01-10 23:01:23+05:30  Cprogrammer
  * reset sgoptind, sgoptpos for repeated calls to subgetopt
  *

--- a/indimail-mta-x/qmail-dkim.c
+++ b/indimail-mta-x/qmail-dkim.c
@@ -37,6 +37,7 @@
 #include "variables.h"
 #include "qmulti.h"
 #include "pidopen.h"
+#include "buffer_defs.h"
 #include "custom_error.h"
 #include <openssl/evp.h>
 
@@ -49,8 +50,8 @@
 
 extern char    *dns_text(char *);
 
-char            inbuf[4096];
-char            outbuf[256];
+char            inbuf[BUFSIZE_IN];
+char            outbuf[BUFSIZE_OUT];
 struct substdio ssin;
 struct substdio ssout;
 

--- a/indimail-mta-x/qmail-poppass.c
+++ b/indimail-mta-x/qmail-poppass.c
@@ -56,7 +56,7 @@
 #include <error.h>
 #include <makeargs.h>
 #include <noreturn.h>
-#include <buffer_defs.h>
+#include "buffer_defs.h"
 #include "auto_uids.h"
 
 static char     ssinbuf[BUFSIZE_OUT];

--- a/indimail-mta-x/qmail-poppass.c
+++ b/indimail-mta-x/qmail-poppass.c
@@ -56,11 +56,12 @@
 #include <error.h>
 #include <makeargs.h>
 #include <noreturn.h>
+#include <buffer_defs.h>
 #include "auto_uids.h"
 
-static char     ssinbuf[1024];
-static char     ssoutbuf[512];
-static char     sserrbuf[512];
+static char     ssinbuf[BUFSIZE_OUT];
+static char     ssoutbuf[BUFSIZE_IN];
+static char     sserrbuf[BUFSIZE_IN];
 static char     upbuf[128];
 static char   **authargs, **passargs;
 static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);

--- a/indimail-mta-x/qmail-poppass.c
+++ b/indimail-mta-x/qmail-poppass.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-poppass.c,v $
+ * Revision 1.8  2024-01-23 01:22:46+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.7  2023-02-14 09:13:01+05:30  Cprogrammer
  * renamed auto_uidv to auto_uidi
  *
@@ -363,7 +366,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_poppass_c()
 {
-	static char    *x = "$Id: qmail-poppass.c,v 1.7 2023-02-14 09:13:01+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-poppass.c,v 1.8 2024-01-23 01:22:46+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidmakeargsh;
 	x++;

--- a/indimail-mta-x/qmail-qfilter.c
+++ b/indimail-mta-x/qmail-qfilter.c
@@ -1,5 +1,5 @@
 /*
- * $Id: qmail-qfilter.c,v 1.21 2023-09-08 00:57:21+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-qfilter.c,v 1.22 2024-01-23 01:22:51+05:30 Cprogrammer Exp mbhangui $
  *
  * Copyright (C) 2001,2004-2005 Bruce Guenter <bruceg@em.ca>
  *
@@ -386,7 +386,7 @@ main(int argc, char *argv[])
 void
 getversion_qmail_qfilter_c()
 {
-	static char    *x = "$Id: qmail-qfilter.c,v 1.21 2023-09-08 00:57:21+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-qfilter.c,v 1.22 2024-01-23 01:22:51+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidqmultih;
 	x++;
@@ -395,6 +395,9 @@ getversion_qmail_qfilter_c()
 
 /*
  * $Log: qmail-qfilter.c,v $
+ * Revision 1.22  2024-01-23 01:22:51+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.21  2023-09-08 00:57:21+05:30  Cprogrammer
  * BUG FIX: qmail-multi, qmail-queue wasn't getting executed
  *

--- a/indimail-mta-x/qmail-qfilter.c
+++ b/indimail-mta-x/qmail-qfilter.c
@@ -36,6 +36,7 @@
 #include "qmail.h"
 #include "qmulti.h"
 #include "custom_error.h"
+#include "buffer_defs.h"
 
 #ifndef TMPDIR
 #define TMPDIR "/tmp"
@@ -188,8 +189,8 @@ copy_fd(int fdin, int fdout, size_t *var)
 	 * Copy the message into the temporary file
 	 */
 	for (bytes = 0;;) {
-		char            buf[BUFSIZE];
-		ssize_t         rd = read(fdin, buf, BUFSIZE);
+		char            buf[BUFSIZE_IN];
+		ssize_t         rd = read(fdin, buf, BUFSIZE_IN);
 
 		if (rd == -1)
 			exit(QQ_READ_ERR);

--- a/indimail-mta-x/qmail-qmqpc.c
+++ b/indimail-mta-x/qmail-qmqpc.c
@@ -1,5 +1,5 @@
 /*
- * $Id: qmail-qmqpc.c,v 1.26 2023-10-27 16:11:50+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-qmqpc.c,v 1.27 2024-01-23 01:22:55+05:30 Cprogrammer Exp mbhangui $
  */
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -331,13 +331,16 @@ again:
 void
 getversion_qmail_qmqpc_c()
 {
-	static char    *x = "$Id: qmail-qmqpc.c,v 1.26 2023-10-27 16:11:50+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-qmqpc.c,v 1.27 2024-01-23 01:22:55+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }
 
 /*
  * $Log: qmail-qmqpc.c,v $
+ * Revision 1.27  2024-01-23 01:22:55+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.26  2023-10-27 16:11:50+05:30  Cprogrammer
  * replace hard-coded exit values with constants from qmail.h
  *

--- a/indimail-mta-x/qmail-qmqpc.c
+++ b/indimail-mta-x/qmail-qmqpc.c
@@ -28,6 +28,7 @@
 #include "auto_control.h"
 #include "control.h"
 #include "variables.h"
+#include "buffer_defs.h"
 
 #define PORT_QMQP 628
 ssize_t         saferead(int fd, char *_buf, size_t len);
@@ -37,7 +38,7 @@ static int      lasterror = 55;
 static int      timeoutremote = 60;
 static int      timeoutconnect = 10;
 static int      qmqpfd;
-static char     buf[1024];
+static char     buf[BUFSIZE_IN];
 static char     strnum[FMT_ULONG];
 static substdio to = SUBSTDIO_FDBUF(safewrite, -1, buf, sizeof buf);
 static substdio from = SUBSTDIO_FDBUF(saferead, -1, buf, sizeof buf);

--- a/indimail-mta-x/qmail-qmqpd.c
+++ b/indimail-mta-x/qmail-qmqpd.c
@@ -40,14 +40,15 @@
 #include <fmt.h>
 #include <env.h>
 #include <noreturn.h>
+#include <buffer_defs.h>
 #include "qmail.h"
 #include "received.h"
 
 ssize_t         saferead(int fd, char *_buf, size_t len);
 ssize_t         safewrite(int fd, char *_buf, size_t len);
 
-static char     ssinbuf[512];
-static char     ssoutbuf[256];
+static char     ssinbuf[BUFSIZE_IN];
+static char     ssoutbuf[BUFSIZE_OUT];
 static substdio ssin = SUBSTDIO_FDBUF(saferead, 0, ssinbuf, sizeof ssinbuf);
 static substdio ssout = SUBSTDIO_FDBUF(safewrite, 1, ssoutbuf, sizeof ssoutbuf);
 static unsigned long   bytesleft = 100;

--- a/indimail-mta-x/qmail-qmqpd.c
+++ b/indimail-mta-x/qmail-qmqpd.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-qmqpd.c,v $
+ * Revision 1.14  2024-01-23 01:22:59+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.13  2023-10-07 01:34:18+05:30  Cprogrammer
  * added parameter hide for received
  *
@@ -228,7 +231,7 @@ main()
 void
 getversion_qmail_qmqpd_c()
 {
-	static char    *x = "$Id: qmail-qmqpd.c,v 1.13 2023-10-07 01:34:18+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-qmqpd.c,v 1.14 2024-01-23 01:22:59+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qmail-qmqpd.c
+++ b/indimail-mta-x/qmail-qmqpd.c
@@ -40,7 +40,7 @@
 #include <fmt.h>
 #include <env.h>
 #include <noreturn.h>
-#include <buffer_defs.h>
+#include "buffer_defs.h"
 #include "qmail.h"
 #include "received.h"
 

--- a/indimail-mta-x/qmail-qmtpd.c
+++ b/indimail-mta-x/qmail-qmtpd.c
@@ -10,6 +10,7 @@
 #include <env.h>
 #include <sig.h>
 #include <scan.h>
+#include <buffer_defs.h>
 #include "qmail.h"
 #include "rcpthosts.h"
 #include "control.h"
@@ -51,7 +52,7 @@ saferead(int fd, char *buf, size_t len)
 	return r;
 }
 
-char            ssinbuf[512];
+char            ssinbuf[BUFSIZE_OUT];
 substdio        ssin = SUBSTDIO_FDBUF(saferead, 0, ssinbuf, sizeof ssinbuf);
 
 unsigned long

--- a/indimail-mta-x/qmail-qmtpd.c
+++ b/indimail-mta-x/qmail-qmtpd.c
@@ -10,7 +10,7 @@
 #include <env.h>
 #include <sig.h>
 #include <scan.h>
-#include <buffer_defs.h>
+#include "buffer_defs.h"
 #include "qmail.h"
 #include "rcpthosts.h"
 #include "control.h"

--- a/indimail-mta-x/qmail-qmtpd.c
+++ b/indimail-mta-x/qmail-qmtpd.c
@@ -1,5 +1,5 @@
 /*
- * $Id: qmail-qmtpd.c,v 1.18 2023-10-07 01:25:42+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-qmtpd.c,v 1.19 2024-01-23 01:23:04+05:30 Cprogrammer Exp mbhangui $
  */
 #include <unistd.h>
 #include <stralloc.h>
@@ -308,13 +308,16 @@ main()
 void
 getversion_qmail_qmtpd_c()
 {
-	static char    *x = "$Id: qmail-qmtpd.c,v 1.18 2023-10-07 01:25:42+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-qmtpd.c,v 1.19 2024-01-23 01:23:04+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }
 
 /*
  * $Log: qmail-qmtpd.c,v $
+ * Revision 1.19  2024-01-23 01:23:04+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.18  2023-10-07 01:25:42+05:30  Cprogrammer
  * use env variable HIDE_HOST to hide IP, host in received headers
  *

--- a/indimail-mta-x/qmail-queue.c
+++ b/indimail-mta-x/qmail-queue.c
@@ -62,7 +62,7 @@ static char    *tcpremoteip;
 static char    *received;
 static char    *pidfn, *messfn, *todofn, *intdfn;
 static char    *origin; /* "X-Originating-IP: 10.0.0.1\n" */
-static char     inbuf[2048], outbuf[256], logbuf[2048];
+static char     inbuf[BUFSIZE_IN], outbuf[BUFSIZE_OUT], logbuf[BUFSIZE_IN];
 static int      messfd, intdfd, match;
 static int      flagmademess = 0;
 static int      flagmadeintd = 0;

--- a/indimail-mta-x/qmail-queue.c
+++ b/indimail-mta-x/qmail-queue.c
@@ -62,7 +62,7 @@ static char    *tcpremoteip;
 static char    *received;
 static char    *pidfn, *messfn, *todofn, *intdfn;
 static char    *origin; /* "X-Originating-IP: 10.0.0.1\n" */
-static char     inbuf[BUFSIZE_IN], outbuf[BUFSIZE_OUT], logbuf[BUFSIZE_IN];
+static char     inbuf[BUFSIZE_IN], outbuf[BUFSIZE_OUT], logbuf[BUFSIZE_OUT];
 static int      messfd, intdfd, match;
 static int      flagmademess = 0;
 static int      flagmadeintd = 0;

--- a/indimail-mta-x/qmail-queue.c
+++ b/indimail-mta-x/qmail-queue.c
@@ -1,5 +1,5 @@
 /*
- * $Id: qmail-queue.c,v 1.92 2023-12-25 09:30:45+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-queue.c,v 1.93 2024-01-23 01:23:08+05:30 Cprogrammer Exp mbhangui $
  */
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -1191,7 +1191,7 @@ main()
 void
 getversion_qmail_queue_c()
 {
-	static char    *x = "$Id: qmail-queue.c,v 1.92 2023-12-25 09:30:45+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-queue.c,v 1.93 2024-01-23 01:23:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidmakeargsh;
 	x++;
@@ -1199,6 +1199,9 @@ getversion_qmail_queue_c()
 #endif
 /*
  * $Log: qmail-queue.c,v $
+ * Revision 1.93  2024-01-23 01:23:08+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.92  2023-12-25 09:30:45+05:30  Cprogrammer
  * made DEATH configurable
  *

--- a/indimail-mta-x/qmail-remote.c
+++ b/indimail-mta-x/qmail-remote.c
@@ -843,12 +843,13 @@ safewrite(int fd, char *buf, int len)
 	return r;
 }
 
-char            inbuf[1500];
-char            smtptobuf[1500];
-substdio        ssin = SUBSTDIO_FDBUF(read, 0, inbuf, sizeof inbuf);
+#include "buffer_defs.h"
+static char     inbuf[BUFSIZE_REMOTE];
+static char     smtpfrombuf[BUFSIZE_SMALL];
+static char     smtptobuf[BUFSIZE_IN];
+static substdio ssin = SUBSTDIO_FDBUF(read, 0, inbuf, sizeof inbuf);
+static substdio smtpfrom = SUBSTDIO_FDBUF(saferead, -1, smtpfrombuf, sizeof smtpfrombuf);
 substdio        smtpto = SUBSTDIO_FDBUF(safewrite, -1, smtptobuf, sizeof smtptobuf);
-char            smtpfrombuf[128];
-substdio        smtpfrom = SUBSTDIO_FDBUF(saferead, -1, smtpfrombuf, sizeof smtpfrombuf);
 
 void
 get1(char *ch)
@@ -1051,8 +1052,8 @@ va_dcl
 void
 blast()
 {
-	int             r, i, j, eom;
-	char            in[4096], out[4096 * 2 + 1];
+	int             r, i, o, eom;
+	char            out[BUFSIZE_REMOTE * 2 + 1];
 
 	for (r = 0; r < qqeh.len; r++) {
 		if (qqeh.s[r] == '\n' && substdio_put(&smtpto, "\r", 1) == -1)
@@ -1061,28 +1062,28 @@ blast()
 			temp_write();
 	}
 	for (eom = 1;;) { /* Bruce Guenter's fastremote patch */
-		if (!(r = substdio_get(&ssin, in, sizeof(in))))
+		if (!(r = substdio_get(&ssin, inbuf, sizeof(inbuf))))
 			break;
 		if (r == -1)
 			temp_read();
-		for (i = j = 0; i < r; ) {
-			if (eom && in[i] == '.') {
-				out[j++] = '.';
-				out[j++] = in[i++];
+		for (i = o = 0; i < r; ) {
+			if (eom && inbuf[i] == '.') {
+				out[o++] = '.';
+				out[o++] = inbuf[i++];
 			}
 			eom = 0;
 			while (i < r) {
-				if (in[i] == '\n') {
+				if (inbuf[i] == '\n') { /* eom */
 					i++;
 					eom = 1;
-					out[j++] = '\r';
-					out[j++] = '\n';
+					out[o++] = '\r';
+					out[o++] = '\n';
 					break;
 				}
-				out[j++] = in[i++];
+				out[o++] = inbuf[i++];
 			} /*- while (i < r) */
-		} /*- for (i = j = 0; i < r; ) */
-		if (substdio_put(&smtpto, out, j) == -1)
+		} /*- for (i = o = 0; i < r; ) */
+		if (substdio_put(&smtpto, out, o) == -1)
 			temp_write();
 	}
 	if (!eom)

--- a/indimail-mta-x/qmail-remote.c
+++ b/indimail-mta-x/qmail-remote.c
@@ -1,6 +1,6 @@
 /*-
  * RCS log at bottom
- * $Id: qmail-remote.c,v 1.170 2023-08-28 22:28:48+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-remote.c,v 1.171 2024-01-23 01:23:16+05:30 Cprogrammer Exp mbhangui $
  */
 #include <unistd.h>
 #include <sys/types.h>
@@ -3729,13 +3729,16 @@ main(int argc, char **argv)
 void
 getversion_qmail_remote_c()
 {
-	static char    *x = "$Id: qmail-remote.c,v 1.170 2023-08-28 22:28:48+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-remote.c,v 1.171 2024-01-23 01:23:16+05:30 Cprogrammer Exp mbhangui $";
 	x = sccsidqrdigestmd5h;
 	x++;
 }
 
 /*
  * $Log: qmail-remote.c,v $
+ * Revision 1.171  2024-01-23 01:23:16+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.170  2023-08-28 22:28:48+05:30  Cprogrammer
  * BUG: fixed extra connect being made for servers without STARTTLS capability
  *

--- a/indimail-mta-x/qmail.h
+++ b/indimail-mta-x/qmail.h
@@ -1,5 +1,5 @@
 /*
- * $Id: qmail.h,v 1.11 2024-01-20 23:27:50+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail.h,v 1.12 2024-01-23 01:22:42+05:30 Cprogrammer Exp mbhangui $
  */
 #ifndef QMAIL_H
 #define QMAIL_H
@@ -101,6 +101,9 @@ unsigned long   qmail_qp(struct qmail *);
 
 /*
  * $Log: qmail.h,v $
+ * Revision 1.12  2024-01-23 01:22:42+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.11  2024-01-20 23:27:50+05:30  Cprogrammer
  * increased qmail-queue buffer to 8192 for performance
  *

--- a/indimail-mta-x/qmail.h
+++ b/indimail-mta-x/qmail.h
@@ -5,6 +5,7 @@
 #define QMAIL_H
 
 #include "substdio.h"
+#include "buffer_defs.h"
 
 #ifndef CUSTOM_ERR_FD
 #define CUSTOM_ERR_FD 2
@@ -21,7 +22,7 @@ struct qmail
 	int             fde; /*- fd envelope */
 	int             fdc; /*- fd custom */
 	substdio        ss;
-	char            buf[8192];
+	char            buf[BUFSIZE_MESS];
 };
 
 int             qmail_open(struct qmail *);

--- a/indimail-mta-x/qnotify.c
+++ b/indimail-mta-x/qnotify.c
@@ -56,7 +56,7 @@
 #include <pathexec.h>
 #include <strerr.h>
 #include <noreturn.h>
-#include <buffer_defs.h>
+#include "buffer_defs.h"
 #include "qmail.h"
 #include "sgetopt.h"
 #include "set_environment.h"

--- a/indimail-mta-x/qnotify.c
+++ b/indimail-mta-x/qnotify.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qnotify.c,v $
+ * Revision 1.13  2024-01-23 01:23:21+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.12  2021-08-29 23:27:08+05:30  Cprogrammer
  * define functions as noreturn
  *
@@ -581,7 +584,7 @@ main(int argc, char **argv)
 void
 getversion_qnotify_c()
 {
-	static char    *x = "$Id: qnotify.c,v 1.12 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qnotify.c,v 1.13 2024-01-23 01:23:21+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qnotify.c
+++ b/indimail-mta-x/qnotify.c
@@ -56,6 +56,7 @@
 #include <pathexec.h>
 #include <strerr.h>
 #include <noreturn.h>
+#include <buffer_defs.h>
 #include "qmail.h"
 #include "sgetopt.h"
 #include "set_environment.h"
@@ -102,8 +103,8 @@
  */
 
 static char     strnum[FMT_ULONG];
-static char     ssoutbuf[512];
-static char     sserrbuf[512];
+static char     ssoutbuf[BUFSIZE_OUT];
+static char     sserrbuf[BUFSIZE_OUT];
 static char    *usage = "usage: qnotify [-n][-h]\n";
 static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
 static substdio sserr = SUBSTDIO_FDBUF(write, 2, sserrbuf, sizeof(sserrbuf));

--- a/indimail-mta-x/rrt.c
+++ b/indimail-mta-x/rrt.c
@@ -55,7 +55,7 @@
 #include <strerr.h>
 #include <pathexec.h>
 #include <noreturn.h>
-#include <buffer_defs.h>
+#include "buffer_defs.h"
 #include "variables.h"
 #include "control.h"
 #include "qmail.h"

--- a/indimail-mta-x/rrt.c
+++ b/indimail-mta-x/rrt.c
@@ -1,5 +1,8 @@
 /*
  * $Log: rrt.c,v $
+ * Revision 1.13  2024-01-23 01:23:26+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.12  2021-12-05 09:16:37+05:30  Cprogrammer
  * fixed command line arguments for return-path and recipient
  *
@@ -497,7 +500,7 @@ main(int argc, char **argv)
 void
 getversion_rr_c()
 {
-	static char    *x = "$Id: rrt.c,v 1.12 2021-12-05 09:16:37+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: rrt.c,v 1.13 2024-01-23 01:23:26+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/rrt.c
+++ b/indimail-mta-x/rrt.c
@@ -55,6 +55,7 @@
 #include <strerr.h>
 #include <pathexec.h>
 #include <noreturn.h>
+#include <buffer_defs.h>
 #include "variables.h"
 #include "control.h"
 #include "qmail.h"
@@ -74,7 +75,7 @@
 #define USAGE_ERR 7
 #define PARSE_ERR 8
 
-static char     ssoutbuf[512], sserrbuf[512], strnum[FMT_ULONG];
+static char     ssoutbuf[BUFSIZE_OUT], sserrbuf[BUFSIZE_OUT], strnum[FMT_ULONG];
 static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
 static substdio sserr = SUBSTDIO_FDBUF(write, 2, sserrbuf, sizeof(sserrbuf));
 static char    *usage = "usage: rrt [-n][-b]\n";

--- a/indimail-mta-x/smtpd.c
+++ b/indimail-mta-x/smtpd.c
@@ -1,6 +1,6 @@
 /*
  * RCS log at bottom
- * $Id: smtpd.c,v 1.319 2024-01-20 23:34:14+05:30 Cprogrammer Exp mbhangui $
+ * $Id: smtpd.c,v 1.320 2024-01-23 01:23:31+05:30 Cprogrammer Exp mbhangui $
  */
 #include <unistd.h>
 #include <fcntl.h>
@@ -157,7 +157,7 @@ static SSL     *ssl = NULL;
 static struct strerr *se;
 #endif
 static int      tr_success = 0;
-static char    *revision = "$Revision: 1.319 $";
+static char    *revision = "$Revision: 1.320 $";
 static char    *protocol = "SMTP";
 static stralloc proto = { 0 };
 static stralloc Revision = { 0 };
@@ -7360,6 +7360,9 @@ addrrelay()
 
 /*
  * $Log: smtpd.c,v $
+ * Revision 1.320  2024-01-23 01:23:31+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.319  2024-01-20 23:34:14+05:30  Cprogrammer
  * fixed logerr cloberring strnum
  *
@@ -7776,7 +7779,7 @@ addrrelay()
 char           *
 getversion_smtpd_c()
 {
-	static char    *x = "$Id: smtpd.c,v 1.319 2024-01-20 23:34:14+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: smtpd.c,v 1.320 2024-01-23 01:23:31+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 	return revision + 11;

--- a/indimail-mta-x/smtpd.c
+++ b/indimail-mta-x/smtpd.c
@@ -54,6 +54,7 @@
 #include "mail_acl.h"
 #include "do_match.h"
 #include "valid_hname.h"
+#include <buffer_defs.h>
 
 #ifdef TLS
 #include <tls.h>
@@ -217,13 +218,13 @@ static char    *remoteip4;
 #endif
 static char    **childargs;
 
-static char     ssinbuf[1024];
+static char     ssinbuf[BUFSIZE_IN];
 static substdio ssin = SUBSTDIO_FDBUF(saferead, 0, ssinbuf, sizeof ssinbuf);
-static char     ssoutbuf[512];
+static char     ssoutbuf[BUFSIZE_OUT];
 static substdio ssout = SUBSTDIO_FDBUF(safewrite, 1, ssoutbuf, sizeof ssoutbuf);
-static char     sserrbuf[512];
+static char     sserrbuf[BUFSIZE_OUT];
 static substdio sserr = SUBSTDIO_FDBUF(write, 2, sserrbuf, sizeof (sserrbuf));
-static char     upbuf[128];
+static char     upbuf[BUFSIZE_SMALL];
 static substdio ssup;
 
 static my_ulong databytes = 0;
@@ -2817,7 +2818,7 @@ smtp_init(int force_flag)
 	chkgrcptok = chkgrcptokp = spfok = sppok = nodnschecksok = 0;
 	briok = brhok = badhelook = acclistok = bodyok = 0;
 	tarpitcount = tarpitdelay = maxrcptcount = sigsok = greetdelay = qregex = 0;
-	batvFn = bmfFn = bmfFnp = bhrcpFn = bhrcpFnp = bhsndFn = bhsndFnp = rcpFn = NULL;
+	bmfFn = bmfFnp = bhrcpFn = bhrcpFnp = bhsndFn = bhsndFnp = rcpFn = NULL;
 	rcpFnp = accFn = nodnsFn = badipFn = badhostFn = badheloFn = NULL;
 	grcptFn = grcptFnp = spfFn = spfFnp = sigsFn = bodyFn = NULL;
 	tarpitcountok = tarpitdelayok = maxrcptcountok = greetdelayok = qregexok = 0;

--- a/indimail-mta-x/smtpd.c
+++ b/indimail-mta-x/smtpd.c
@@ -54,7 +54,7 @@
 #include "mail_acl.h"
 #include "do_match.h"
 #include "valid_hname.h"
-#include <buffer_defs.h>
+#include "buffer_defs.h"
 
 #ifdef TLS
 #include <tls.h>

--- a/indimail-mta-x/spawn-filter.c
+++ b/indimail-mta-x/spawn-filter.c
@@ -29,6 +29,7 @@
 #include "auto_prefix.h"
 #include "variables.h"
 #include "envrules.h"
+#include "buffer_defs.h"
 
 static int      mkTempFile(int);
 static int      run_mailfilter(char *, char *, char *, char *, char **);
@@ -56,7 +57,7 @@ log_spam(char *arg1, char *arg2, char *size, stralloc *line)
 	char           *fifo_name;
 	char            strnum[FMT_ULONG];
 	struct stat     statbuf;
-	static char     spambuf[256], inbuf[1024];
+	static char     spambuf[BUFSIZE_OUT], inbuf[BUFSIZE_IN];
 	static substdio spamin;
 	static substdio spamout;
 

--- a/indimail-mta-x/spawn-filter.c
+++ b/indimail-mta-x/spawn-filter.c
@@ -1,5 +1,5 @@
 /*
- * $Id: spawn-filter.c,v 1.86 2024-01-09 12:38:29+05:30 Cprogrammer Exp mbhangui $
+ * $Id: spawn-filter.c,v 1.87 2024-01-23 01:23:36+05:30 Cprogrammer Exp mbhangui $
  */
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -675,7 +675,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_spawn_filter_c()
 {
-	static char    *x = "$Id: spawn-filter.c,v 1.86 2024-01-09 12:38:29+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: spawn-filter.c,v 1.87 2024-01-23 01:23:36+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidreporth;
 	x = sccsidgetdomainth;
@@ -686,6 +686,9 @@ getversion_qmail_spawn_filter_c()
 
 /*
  * $Log: spawn-filter.c,v $
+ * Revision 1.87  2024-01-23 01:23:36+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.86  2024-01-09 12:38:29+05:30  Cprogrammer
  * display filter used for mail rejected message
  *

--- a/indimail-mta-x/starttls.c
+++ b/indimail-mta-x/starttls.c
@@ -249,12 +249,13 @@ safewrite(int fd, char *buf, int len)
 	return r;
 }
 
-char            inbuf[1500];
-char            smtptobuf[1500];
-substdio        ssin = SUBSTDIO_FDBUF(read, 0, inbuf, sizeof inbuf);
+#include "buffer_defs.h"
+static char     inbuf[BUFSIZE_MESS];
+static char     smtpfrombuf[BUFSIZE_SMALL];
+static char     smtptobuf[BUFSIZE_IN];
+static substdio ssin = SUBSTDIO_FDBUF(read, 0, inbuf, sizeof inbuf);
+static substdio smtpfrom = SUBSTDIO_FDBUF(saferead, -1, smtpfrombuf, sizeof smtpfrombuf);
 substdio        smtpto = SUBSTDIO_FDBUF(safewrite, -1, smtptobuf, sizeof smtptobuf);
-char            smtpfrombuf[128];
-substdio        smtpfrom = SUBSTDIO_FDBUF(saferead, -1, smtpfrombuf, sizeof smtpfrombuf);
 
 void
 outsmtptext()
@@ -920,7 +921,7 @@ get_dane_records(char *host)
 #include <unistd.h>
 #include <substdio.h>
 #include <subfd.h>
-char            smtptobuf[1500];
+char            smtptobuf[1024];
 substdio        smtpto = SUBSTDIO_FDBUF(write, 2, smtptobuf, sizeof smtptobuf);
 unsigned long smtpcode() { return(550);}
 #endif /*- #if defined(HASTLSA) && defined(TLS) */

--- a/indimail-mta-x/starttls.c
+++ b/indimail-mta-x/starttls.c
@@ -1,5 +1,5 @@
 /*
- * $Id: starttls.c,v 1.17 2023-07-07 10:51:32+05:30 Cprogrammer Exp mbhangui $
+ * $Id: starttls.c,v 1.18 2024-01-23 01:23:41+05:30 Cprogrammer Exp mbhangui $
  */
 #include "hastlsa.h"
 #if defined(HASTLSA) && defined(TLS)
@@ -929,13 +929,16 @@ unsigned long smtpcode() { return(550);}
 void
 getversion_starttls_c()
 {
-	static char    *x = "$Id: starttls.c,v 1.17 2023-07-07 10:51:32+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: starttls.c,v 1.18 2024-01-23 01:23:41+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }
 
 /*
  * $Log: starttls.c,v $
+ * Revision 1.18  2024-01-23 01:23:41+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.17  2023-07-07 10:51:32+05:30  Cprogrammer
  * use NULL instead of 0 for null pointer
  *

--- a/indimail-mta-x/starttls.h
+++ b/indimail-mta-x/starttls.h
@@ -12,6 +12,7 @@
 #define _STARTTLS_H
 #include "ipalloc.h"
 #include "tlsarralloc.h"
+#include "buffer_defs.h"
 
 #ifndef	lint
 static char     sccsidstarttlsh[] = "$Id: starttls.h,v 1.2 2023-01-03 17:43:29+05:30 Cprogrammer Exp mbhangui $";

--- a/indimail-mta-x/starttls.h
+++ b/indimail-mta-x/starttls.h
@@ -1,5 +1,8 @@
 /*
  * $Log: starttls.h,v $
+ * Revision 1.3  2024-01-23 01:23:45+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.2  2023-01-03 17:43:29+05:30  Cprogrammer
  * define variables used in qmail-daned, dnstlsarr as extern
  *
@@ -15,7 +18,7 @@
 #include "buffer_defs.h"
 
 #ifndef	lint
-static char     sccsidstarttlsh[] = "$Id: starttls.h,v 1.2 2023-01-03 17:43:29+05:30 Cprogrammer Exp mbhangui $";
+static char     sccsidstarttlsh[] = "$Id: starttls.h,v 1.3 2024-01-23 01:23:45+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 void            die_control(char *, char *);

--- a/indimail-mta-x/surblfilter.c
+++ b/indimail-mta-x/surblfilter.c
@@ -31,8 +31,8 @@
 #include <mess822.h>
 #include <base64.h>
 #include <noreturn.h>
-#include <buffer_defs.h>
 
+#include "buffer_defs.h"
 #include "auto_control.h"
 #include "control.h"
 #include "dns.h"

--- a/indimail-mta-x/surblfilter.c
+++ b/indimail-mta-x/surblfilter.c
@@ -1,5 +1,5 @@
 /*
- * $Id: surblfilter.c,v 1.18 2023-09-07 20:50:26+05:30 Cprogrammer Exp mbhangui $
+ * $Id: surblfilter.c,v 1.19 2024-01-23 01:23:51+05:30 Cprogrammer Exp mbhangui $
  */
 #include <unistd.h>
 #include <fcntl.h>
@@ -971,13 +971,16 @@ main(int argc, char **argv)
 void
 getversion_surblfilter_c()
 {
-	static char    *x = "$Id: surblfilter.c,v 1.18 2023-09-07 20:50:26+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: surblfilter.c,v 1.19 2024-01-23 01:23:51+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }
 
 /*
  * $Log: surblfilter.c,v $
+ * Revision 1.19  2024-01-23 01:23:51+05:30  Cprogrammer
+ * include buffer_defs.h for buffer size definitions
+ *
  * Revision 1.18  2023-09-07 20:50:26+05:30  Cprogrammer
  * display the SURB blocked uri in message
  *

--- a/indimail-mta-x/surblfilter.c
+++ b/indimail-mta-x/surblfilter.c
@@ -31,6 +31,7 @@
 #include <mess822.h>
 #include <base64.h>
 #include <noreturn.h>
+#include <buffer_defs.h>
 
 #include "auto_control.h"
 #include "control.h"
@@ -64,7 +65,7 @@ int             l3ok = 0;
 struct constmap mapl3;
 
 struct substdio ssin, ssout, sserr, ssdbg;
-static char     ssinbuf[1024], ssoutbuf[512], sserrbuf[512], ssdbgbuf[512];
+static char     ssinbuf[BUFSIZE_IN], ssoutbuf[BUFSIZE_OUT], sserrbuf[BUFSIZE_OUT], ssdbgbuf[BUFSIZE_OUT];
 
 static struct
 {


### PR DESCRIPTION
Inspired by Erwin Hoffman's s/qmail 4.3

1. Create #defines for various buffer sizes used by qmail in buffer_defs.h
2. Update programs using hard coded buffer sizes to use buffer_defs.h