### PR TITLE
add user defined filters in control/filters.d

### DIFF
--- a/indimail-mta-x/DIRS.in
+++ b/indimail-mta-x/DIRS.in
@@ -42,3 +42,4 @@ d:root:qcerts:02775:@qsysconfdir@/certs::
 d:root:qmail:02775:@qsysconfdir@/tcp::
 d:root:root:0755:@qsysconfdir@/perms.d::
 d:root:root:0755:@qsysconfdir@/perms.d/indimail-mta::
+d:root:root:0755:@qsysconfdir@/filters.d::

--- a/indimail-mta-x/doc/ChangeLog
+++ b/indimail-mta-x/doc/ChangeLog
@@ -102,7 +102,7 @@ Release @version@-@release@ Start 02/01/2024 End XX/XX/XXXX
 55. qmail-multi (mailfilter.c): added exit code 99 (blackhole) for
     compatibility with qmail-qfilter
 56. qfrontend, qf-log-subject, qf-smtp-ratelimit: make script compatible
-	with FILTERARGS as well as qmail-qfilter
+    with FILTERARGS as well as qmail-qfilter
 57. qfrontend: use control/filters.d directory for user defined scripts
 58. qmail-qfilter.c: added exit code 2 (blackhole) for compatibility with
     qmail-multi

--- a/indimail-mta-x/doc/ChangeLog
+++ b/indimail-mta-x/doc/ChangeLog
@@ -96,6 +96,17 @@ Release @version@-@release@ Start 02/01/2024 End XX/XX/XXXX
 52. mailfilter.c: return permanent rejection for both 100 and
     QQ_PERM_MSG_REJECT codes
 53. test-indimail-mta: added additional tests for FILTERARGS, qmail-qfilter
+- 20/02/2024
+54. indimail-mta.spec, DIRS.in: added control/filters.d for user defined
+    filters
+55. qmail-multi (mailfilter.c): added exit code 99 (blackhole) for
+    compatibility with qmail-qfilter
+56. qfrontend, qf-log-subject, qf-smtp-ratelimit: make script compatible
+	with FILTERARGS as well as qmail-qfilter
+57. qfrontend: use control/filters.d directory for user defined scripts
+58. qmail-qfilter.c: added exit code 2 (blackhole) for compatibility with
+    qmail-multi
+59. qmail-showctl.c: added display of user filter directory control/filters.d
 
 * Mon Jan 01 2024 18:55:50 +0000 Manvendra Bhangui <indimail-mta@indimail.org> 3.0.6-1.1%{?dist}
 Release 3.0.6-1.1 Start 25/10/2023 End 01/01/2024

--- a/indimail-mta-x/indimail-mta.spec.in
+++ b/indimail-mta-x/indimail-mta.spec.in
@@ -1,6 +1,6 @@
 #
 #
-# $Id: indimail-mta.spec.in,v 1.401 2024-02-18 17:02:34+05:30 Cprogrammer Exp mbhangui $
+# $Id: indimail-mta.spec.in,v 1.402 2024-02-20 22:17:55+05:30 Cprogrammer Exp mbhangui $
 %undefine _missing_build_ids_terminate_build
 %global _unpackaged_files_terminate_build 1
 
@@ -489,6 +489,7 @@ echo ../resolv.conf 1>&3
 %dir %attr(0755,root,qmail)                        %{qsysconfdir}/control/global_vars
 %dir %attr(0755,root,root)                         %{qsysconfdir}/perms.d
 %dir %attr(0755,root,root)                         %{qsysconfdir}/perms.d/%{name}
+%dir %attr(0755,root,root)                         %{qsysconfdir}/filters.d
 %dir %attr(2775,root,qmail)                        %{qsysconfdir}/tcp
 %dir %attr(2775,root,qmail)                        %{qsysconfdir}/users
 %if "%{mandir}" != "/usr/share/man"

--- a/indimail-mta-x/mailfilter.c
+++ b/indimail-mta-x/mailfilter.c
@@ -1,5 +1,5 @@
 /*
- * $Id: mailfilter.c,v 1.4 2024-02-19 22:45:39+05:30 Cprogrammer Exp mbhangui $
+ * $Id: mailfilter.c,v 1.5 2024-02-20 22:18:10+05:30 Cprogrammer Exp mbhangui $
  */
 #include <unistd.h>
 #include <env.h>
@@ -63,6 +63,7 @@ mailfilter(int argc, char **argv, char *filterargs)
 	case 0:
 		return (qmulti(0, argc, argv));
 	case 2:
+	case 99: /*- compatability with qmail-qfilter */
 		return (0); /*- Blackhole */
 	case 88: /*- exit with custom error code with error code string from stderr */
 		_exit(QQ_CUSTOM_ERR);
@@ -81,7 +82,7 @@ mailfilter(int argc, char **argv, char *filterargs)
 void
 getversion_mailfilter_c()
 {
-	static char    *x = "$Id: mailfilter.c,v 1.4 2024-02-19 22:45:39+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: mailfilter.c,v 1.5 2024-02-20 22:18:10+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidmailfilterh;
 	x = sccsidmktempfileh;
@@ -92,6 +93,9 @@ getversion_mailfilter_c()
 
 /*
  * $Log: mailfilter.c,v $
+ * Revision 1.5  2024-02-20 22:18:10+05:30  Cprogrammer
+ * added exit code 99 for compatibility with qmail-qfilter blackhole
+ *
  * Revision 1.4  2024-02-19 22:45:39+05:30  Cprogrammer
  * return permanent rejection for both 100 and QQ_PERM_MSG_REJECT codes
  *

--- a/indimail-mta-x/qf-log-subject.in
+++ b/indimail-mta-x/qf-log-subject.in
@@ -1,12 +1,19 @@
 #
 # $Log: qf-log-subject.in,v $
+# Revision 1.2  2024-02-20 22:20:27+05:30  Cprogrammer
+# make script compatible with FILTERARGS as well as qmail-qfilter
+#
 # Revision 1.1  2021-08-03 16:15:05+05:30  Cprogrammer
 # Initial revision
 #
 #
-# $Id: qf-log-subject.in,v 1.1 2021-08-03 16:15:05+05:30 Cprogrammer Exp mbhangui $
+# $Id: qf-log-subject.in,v 1.2 2024-02-20 22:20:27+05:30 Cprogrammer Exp mbhangui $
 #
 
+[ -n "$ENVSIZE" -a -n "$MSGSIZE" ] && qmail_qfilter=1 || qmail_qfilter=0
+if [ ! -f /proc/$$/3 ] ; then
+	[ $qmail_qfilter -eq 1 ] && exit 0 || exec /bin/cat
+fi
 # read headers
 while read line
 do
@@ -24,7 +31,7 @@ do
 done
 
 # read envelope
-var=`tr ["\0"] ["\n"] 0<&3`
+var=$(tr ["\0"] ["\n"] 0<&3)
 for i in $var
 do
 	first=$(echo $i|cut -c1)
@@ -43,7 +50,8 @@ if [ -n "$TO" -a -n "$FROM" -a -n "$subject" -a -n "$date" ] ; then
 	else
 		echo "Date:$date, Subject:$subject, From: $FROM, To: $TO" | @prefix@/sbin/splogger
 	fi
-	exit $?
+	ret=$?
+	[ $qmail_qfilter -eq 1 ] && exit $ret || /bin/cat && exit $ret
 else
-	exit 0
+	[ $qmail_qfilter -eq 1 ] && exit 0 || exec /bin/cat
 fi

--- a/indimail-mta-x/qf-smtp-ratelimit.in
+++ b/indimail-mta-x/qf-smtp-ratelimit.in
@@ -1,5 +1,8 @@
 #
 # $Log: qf-smtp-ratelimit.in,v $
+# Revision 1.4  2024-02-20 22:23:49+05:30  Cprogrammer
+# make script compatible with FILTERARGS as well as qmail-qfilter
+#
 # Revision 1.3  2021-08-03 15:54:52+05:30  Cprogrammer
 # replaced /bin/cat with exit 0 which does the same thing
 #
@@ -10,11 +13,13 @@
 # Initial revision
 #
 #
+
+[ -n "$ENVSIZE" -a -n "$MSGSIZE" ] && qmail_qfilter=1 || qmail_qfilter=0
 if [ ! -d HOME/domains/$QMAILHOST ] ; then
-	exit 0
+	[ $qmail_qfilter -eq 1 ] && exit 0 || exec /bin/cat
 fi
 if [ ! -d HOME/domains/$QMAILHOST/smtp_timestamps ] ; then
-	exit 0
+	[ $qmail_qfilter -eq 1 ] && exit 0 || exec /bin/cat
 fi
 [ -z "$SMTP_RATE" ] && SMTP_RATE=30
 cur_time=`date +%s`
@@ -30,14 +35,14 @@ if [ -f HOME/domains/$QMAILHOST/smtp_timestamps/"$QMAILUSER"@"$QMAILHOST".t ] ; 
 		diff=`expr $cur_time - $ftime`
 		if [ $diff -gt 1800 ] ; then
 			echo 1 > HOME/domains/$QMAILHOST/smtp_timestamps/"$QMAILUSER"@"$QMAILHOST".t
-			exit 0
+			[ $qmail_qfilter -eq 1 ] && exit 0 || exec /bin/cat
 		else
 			mcount=`expr $mcount + 1`
 			echo $mcount > HOME/domains/$QMAILHOST/smtp_timestamps/"$QMAILUSER"@"$QMAILHOST".t
-			exit 0
+			[ $qmail_qfilter -eq 1 ] && exit 0 || exec /bin/cat
 		fi
 	fi
 else
 	echo 1 > HOME/domains/$QMAILHOST/smtp_timestamps/"$QMAILUSER"@"$QMAILHOST".t
-	exit 0
+	[ $qmail_qfilter -eq 1 ] && exit 0 || exec /bin/cat
 fi

--- a/indimail-mta-x/qfrontend.9
+++ b/indimail-mta-x/qfrontend.9
@@ -4,12 +4,22 @@
 qfrontend \- frontend for executing qmail-qfilter filters
 
 .SH SYNOPSIS
-\fBqfrontend\fR(1) is a frontend for \fBqmail-qfilter\fR(1) that can be
-called as qmail-queue by setting \fBQMAILQUEUE\fR environment variable.
-It looks at control file @controldir@/qfilters for filters to be executed in
-@libexecdir@/qfilters. A filter is any file which is prefixed with
-\fBqf\fR-. If there are multiple scripts, they will be executed in
-alphabetical order.
+\fBqfrontend\fR(1) is a frontend for running multiple filters by
+\fBqmail-multi\fR(8) or \fBqmail-qfilter\fR(1). \fBqfrontent\fR(1) can be
+by setting \fBQMAILQUEUE\fR environment variable.
+
+\fBqfrontend\fR(8) uses \fBqmail-qfilter\fR(8) if \fBUSE_QMAILQFILTER\fR
+environment variable is set, else it uses \fBqmail-multi\fR(8). When
+calling \fBqmail-multi\fR(8), \fBqfrontend\fR(8) unsets \fBSPAMFILTER\fR
+and \fBFILTERARGS\fR environment variable to prevent recursive calls to
+\fBqmail-multi\fR(8).
+
+It first looks at @sysconfdir@/filters.d for user defined filter scripts.
+If \fIfilters.d\fR directory is missing, it looks at control file
+@controldir@/qfilters for filters to be executed in @libexecdir@/qfilters.
+If there are multiple scripts, they will be executed in alphabetical order.
 
 .SH SEE ALSO
-qmail-qfilter(1)
+qmail-multi(1),
+qmail-qfilter(1),
+qmail-queue(1)

--- a/indimail-mta-x/qfrontend.sh
+++ b/indimail-mta-x/qfrontend.sh
@@ -1,5 +1,9 @@
 #
 # $Log: qfrontend.sh,v $
+# Revision 1.5  2024-02-20 22:21:46+05:30  Cprogrammer
+# use control/filters.d directory for user defined filters
+# make script compatible with both FILTERARGS and qmail-qfilter
+#
 # Revision 1.4  2024-02-19 22:46:16+05:30  Cprogrammer
 # skip comments
 #
@@ -14,19 +18,61 @@
 #
 #
 qf=""
+if [ -n "$USE_QMAILQFILTER" ] ; then
+	qqfilter=1
+else
+	qqfilter=0
+fi
+unset SPAMFILTER
+unset FILTERARGS
 [ -n "$CONTROLDIR" ] && controldir=$CONTROLDIR || controldir=@controldir@
 [ -n "$LIBEXECDIR" ] && libexecdir=$LIBEXECDIR || libexecdir=@libexecdir@
-if [ ! -f $controldir/qfilters ] ; then
-	exec qmail-multi
-fi
-for i in $(grep -v "^#" $controldir/qfilters)
-do
-	j=$libexecdir/qfilters/$i
-	if [ -n "$qf" ] ; then
-		qf="$qf -- $j"
-	else
-		qf="$j"
+if [ -d $controldir/filters.d ] ; then
+	for i in $(find $controldir/filters.d -maxdepth 1 -type f)
+	do
+		if [ $qqfilter -eq 1 ] ; then
+			if [ -n "$qf" ] ; then
+				qf="$qf -- $i"
+			else
+				qf="$i"
+			fi
+		else
+			if [ -n "$qf" ] ; then
+				qf="$qf | $i"
+			else
+				qf=$i
+			fi
+		fi
+	done
+else
+	if [ ! -f $controldir/qfilters ] ; then
+		exec @prefix@/sbin/qmail-queue
 	fi
-done
-eval qmail-qfilter $qf
+	for i in $(grep -v "^#" $controldir/qfilters)
+	do
+		j=$libexecdir/qfilters/$i
+		if [ $qqfilter -eq 1 ] ; then
+			if [ -n "$qf" ] ; then
+				qf="$qf -- $j"
+			else
+				qf="$j"
+			fi
+		else
+			if [ -n "$qf" ] ; then
+				qf="$qf | $j"
+			else
+				qf=$j
+			fi
+		fi
+	done
+fi
+if [ -z "$qf" ] ; then
+	exec @prefix@/sbin/qmail-queue
+else
+	if [ $qqfilter -eq 1 ] ; then
+		exec @prefix@/bin/qmail-qfilter $qf
+	else
+		FILTERARGS="$qf" exec @prefix@/sbin/qmail-multi
+	fi
+fi
 exit $?

--- a/indimail-mta-x/qmail-multi.9
+++ b/indimail-mta-x/qmail-multi.9
@@ -10,23 +10,24 @@ qmail-multi \- queue multiplexor and filter
 .SH DESCRIPTION
 \fBqmail-multi(8)\fR is a queue multiplexor and filter for
 \fBqmail-queue(8)\fR. The multiplexor can be turned on by defining
-environment variable \fBQMAILQUEUE\fR=@prefix@/sbin/qmail-multi. Following
-programs use \fBqmail-multi\fR to deposit the mail to the queue - 
-\fBqmail-dkim(8)\fR, \fBqmail-qfilter(1)\fR, \fBqmail-spamfilter(8)\fR,
-\fBqscanq-stdin(8)\fR.
+environment variable \fBQMAILQUEUE\fR=\fI@prefix@/sbin/qmail-multi\fR.
+Following programs use \fBqmail-multi\fR(8) to deposit the mail to the
+queue - \fBqmail-dkim\fR(8), \fBqmail-qfilter\fR(1),
+\fBqmail-spamfilter\fR(8), \fBqscanq-stdin\fR(8).
 
-\fBqmail-multi\fR invokes \fBqmail-queue\fR to deposit the mail. One can
-call any other program by passing command line arguments to
-\fBqmail-multi\fR in \fBQMAILQUEUE\fR. If passed arguments,
-\fBqmail-multi\fR will call \fIqqf\fR. Any arguments after \fIqqf\fR will
+\fBqmail-multi\fR(8) invokes \fBqmail-queue\fR(8) to deposit the mail. One
+can call any other program by passing command line arguments to
+\fBqmail-multi\fR(8) in \fBQMAILQUEUE\fR. If passed arguments,
+\fBqmail-multi\fR(8) will call \fIqqf\fR. Any arguments after \fIqqf\fR will
 be passed as arguments to \fIqqf\fR. You can change the program that
-\fBqmail-multi\fR calls, by setting the environment variable
+\fBqmail-multi\fR(8) calls, by setting the environment variable
 \fBQUEUEPROG\fR, to the path of any qmail-queue frontend. \fBQUEUEPROG\fR
 is typically used when you want to use write your own queue frontend, with
 the queue path available in \fBQUEUEDIR\fR environment variable. If
-\fBQUEUEDIR\fR is set \fBqmail-multi\fR execs \fBqmail-queue\fR (or program
+\fBQUEUEDIR\fR is set \fBqmail-multi\fR(8) execs \fBqmail-queue\fR (or program
 defined by \fBQUEUEPROG\fR without any processing or setting up any
-environment variables.
+environment variables. \fBQUEUEPROG\fR is ignored when \fBqmail-multi\fR(8)
+is passed command line arguments.
 
 The deposition and balancing of mail across multiple queues is controlled
 by the following environment variables.
@@ -44,7 +45,7 @@ e.g. QUEUE_START=1 implies the first queue to be @qmaildir@/queue/queue1
 
 .TP 5
 \fBQUEUE_COUNT\fR This defines the number of queues that should be used for
-load balancing. \fBqmail-multi\fR used a random number to select a queue in
+load balancing. \fBqmail-multi\fR(8) used a random number to select a queue in
 a multi-queue setup.
 
 e.g. QUEUE_START=1, QUEUE_COUNT=5 implies 5 queues @qmaildir@/queue/queue1,
@@ -54,16 +55,16 @@ e.g. QUEUE_START=1, QUEUE_COUNT=5 implies 5 queues @qmaildir@/queue/queue1,
 .B MIN_FREE
 This is the minimum free disk space that should be available in the
 filesystem containing the queues. When free space goes below this value,
-qmail-multi will return a temporary disk full error "qq write error or disk
-full (#4.3.0)". This prevents \fBqmail-send\fR reaching a deadlock in the
-case when disk becomes full and there are bounce messages to be processed.
-\fBqmail-send\fR in this case keeps on retrying bounce message which does
-not succeeed because of insufficient disk space to write the bounce. This
-effectively stops processing of local and remote messages and thus disk
-space never gets freed up. \fBqmail-multi\fR prevents this from happening
-by accepting mails only when disk space greater than MIN_FREE is present.
-It uses \fBstatfs(2)\fR (\fBstatvfs\fR on solaris) to get the free space on
-the filesystem.
+\fBqmail-multi\fR(8) will return a temporary disk full error "qq write
+error or disk full (#4.3.0)". This prevents \fBqmail-send\fR reaching a
+deadlock in the case when disk becomes full and there are bounce messages
+to be processed.  \fBqmail-send\fR in this case keeps on retrying bounce
+message which does not succeeed because of insufficient disk space to write
+the bounce. This effectively stops processing of local and remote messages
+and thus disk space never gets freed up. \fBqmail-multi\fR(8) prevents this
+from happening by accepting mails only when disk space greater than
+MIN_FREE is present.  It uses \fBstatfs(2)\fR (\fBstatvfs\fR on solaris) to
+get the free space on the filesystem.
 
 .TP 5
 .B DYNAMIC_QUEUE
@@ -75,24 +76,24 @@ of queue \fIqcount\fR, written by \fBqscheduler\fR(8). The shared memory
 /\fBqueue\fR\fIN\fR has the current concurrency \fIC\fR, and the maximum
 concurrency \fIM\fR configured for the queue. The concurrency details are
 written to /\fBqueue\fR\fIN\fR shared memory by \fBqmail-send\fR(8)
-\fBqmail-queue\fR cycles through \fIqcount\fR queues and selects the queue
-with the lowest \fIC\fR / \fIM\fR ratio.
+\fBqmail-queue\fR(8) cycles through \fIqcount\fR queues and selects the
+queue with the lowest \fIC\fR / \fIM\fR ratio.
 
 .PP
-\fBqmail-multi\fR is actually a wrapper for \fBqmail-queue\fR to manage
-multiple queues. \fIN\fR queues can be set up in @qmaildir@ as queue\fI1\fR,
-queue\fI2\fR, ... queue\fIN\fR. \fBqmail-multi\fR does load balancing
-across these \fIN\fR queues by doing exec of \fB qmail-queue\fR with
-QUEUEDIR set to the path of one of these \fIN\fR queues. Each of these
-\fIN\fR queues should be created using \fBqueue-fix(1)\fR program. One
-also needs a program like \fBqscheduler(8)\fR which invokes multiple
-\fBqmail-send(8)\fR with the \fBQUEUEDIR\fR set individualy to path of
-these \fIN\fR queues.
+\fBqmail-multi\fR(8) is actually a wrapper for \fBqmail-queue\fR(8) to
+manage multiple queues. \fIN\fR queues can be set up in @qmaildir@ as
+queue\fI1\fR, queue\fI2\fR, ... queue\fIN\fR. \fBqmail-multi\fR(8) does
+load balancing across these \fIN\fR queues by doing exec of \fB
+qmail-queue\fR with QUEUEDIR set to the path of one of these \fIN\fR
+queues. Each of these \fIN\fR queues should be created using
+\fBqueue-fix\fR(1) program. One also needs a program like
+\fBqscheduler(8)\fR which invokes multiple \fBqmail-send\fR(8) with the
+\fBQUEUEDIR\fR set individualy to path of these \fIN\fR queues.
 
-\fBqmail-multi\fR has the ability to run any filter defined by setting the
-FILTERARGS environment variable. Any command defined by FILTERARGS will be
-run using /bin/sh. The input to this filter will be fd 0 and the output
-will be piped to \fBqmail-queue\fR. e.g.
+\fBqmail-multi\fR(8) has the ability to run any filter defined by setting
+the \fBFILTERARGS\fR environment variable. Any command defined by
+\fBFILTERARGS\fR will be run using /bin/sh. The input to this filter will
+be fd 0 and the output will be piped to \fBqmail-queue\fR(8). e.g.
 
 .EX
 FILTERARGS="/usr/bin/altermime --input=- --disclaimer=/etc/motd"
@@ -116,31 +117,33 @@ filter program
 
 .PP
 .fi
-This gives the ability for the FILTERARG program to read the mail message
-from descriptor 0 before passing it to \fBqmail-queue\fR through the pipe.
+This gives the ability for the \fBFILTERARG\fR program to read the mail
+message from descriptor 0 before passing it to \fBqmail-queue\fR through
+the pipe.
 
-\fBqmail-multi\fR will attempt to make the descriptor 0 seekable if the
-environment variable MAKE_SEEKABLE is defined. This may be necessary for
-certain filter programs which require descriptor to be seekable.
+\fBqmail-multi\fR(8) will attempt to make the descriptor 0 seekable if the
+environment variable \fBMAKE_SEEKABLE\fR is defined. This may be necessary
+for certain filter programs which require descriptor to be seekable.
 
-\fBqmail-multi(8)\fR will bounce the message if the return status from the
+\fBqmail-multi\fR(8) will bounce the message if the return status from the
 filter program is 100. The mail will be blackholed if the return status is
-2. If the return status is non-zero, qmail-multi will exit issuing a
-temporary error.
+2. If the return status is non-zero, \fBqmail-multi\fR(8) will exit issuing
+a temporary error.
 
-\fBqmail-multi\fR generates a random number and divides it by QUEUE_COUNT.
-This remainder is added to QUEUE_START to arrive at which queue to use. It
-then sets the QUEUEDIR=@prefix@/sbin/qmail-queue to queue the mail.
+\fBqmail-multi\fR(8) generates a random number and divides it by
+\fBQUEUE_COUNT\fR. This remainder is added to \fBQUEUE_START\fR to arrive
+at which queue to use. It then sets the
+\fIQUEUEDIR=@prefix@/sbin/qmail-queue\fR to queue the mail.
 
-\fBqmail-multi\fR sets an alarm of 86400 seconds to quit if it doesn't
+\fBqmail-multi\fR(8) sets an alarm of 86400 seconds to quit if it doesn't
 complete. This can be changed by setting \fBDEATH\fR environment variable.
-See the man pages for \fBqmail-queue\fR(8) and indimail-mta-internals(7)
-for more details.
+See the man pages for \fBqmail-queue\fR(8) and
+\fBindimail-mta-internals\fR(7) for more details.
 
 .SH "EXIT CODES"
-\fBqmail-multi\fR does not print diagnostics. It exits 120 if it is not
-able to exec \fBqmail-queue\fR. Apart from this it has the following exit
-codes.
+\fBqmail-multi\fR(8) does not print diagnostics. It exits 120 if it is not
+able to exec \fBqmail-queue\fR(8). Apart from this it has the following
+exit codes.
 
 .EX
 It exits 51 if it cannot allocate memory

--- a/indimail-mta-x/qmail-qfilter.c
+++ b/indimail-mta-x/qmail-qfilter.c
@@ -1,5 +1,5 @@
 /*
- * $Id: qmail-qfilter.c,v 1.23 2024-02-19 22:48:22+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-qfilter.c,v 1.24 2024-02-20 22:25:37+05:30 Cprogrammer Exp mbhangui $
  *
  * Copyright (C) 2001,2004-2005 Bruce Guenter <bruceg@em.ca>
  *
@@ -350,6 +350,7 @@ run_filters(const command *first)
 			{
 			case 0:
 				break;
+			case 2: /*- compatibility with qmail-multi */
 			case QQ_DROP_MSG:
 				_exit(0);
 			case QQ_PERM_MSG_REJECT:
@@ -394,7 +395,7 @@ main(int argc, char *argv[])
 void
 getversion_qmail_qfilter_c()
 {
-	static char    *x = "$Id: qmail-qfilter.c,v 1.23 2024-02-19 22:48:22+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-qfilter.c,v 1.24 2024-02-20 22:25:37+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidqmultih;
 	x++;
@@ -403,6 +404,9 @@ getversion_qmail_qfilter_c()
 
 /*
  * $Log: qmail-qfilter.c,v $
+ * Revision 1.24  2024-02-20 22:25:37+05:30  Cprogrammer
+ * added exit code 2 (blackhole) for compatibility with qmail-multi
+ *
  * Revision 1.23  2024-02-19 22:48:22+05:30  Cprogrammer
  * exit with exit code of filter
  *

--- a/indimail-mta-x/qmail-showctl.c
+++ b/indimail-mta-x/qmail-showctl.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-showctl.c,v $
+ * Revision 1.17  2024-02-20 22:25:56+05:30  Cprogrammer
+ * added control/filters.d directory
+ *
  * Revision 1.16  2023-12-31 08:57:39+05:30  Cprogrammer
  * updated control file list
  *
@@ -546,9 +549,13 @@ show_internals(char *home)
 	substdio_puts(subfdout, auto_sysconfdir);
 	substdio_puts(subfdout, "/certs\n");
 
-	substdio_puts(subfdout, "control      irect dir: ");
+	substdio_puts(subfdout, "control            dir: ");
 	substdio_puts(subfdout, controldir);
 	substdio_puts(subfdout, "\n");
+
+	substdio_puts(subfdout, "filter             dir: ");
+	substdio_puts(subfdout, controldir);
+	substdio_puts(subfdout, "/filters.d\n");
 
 	substdio_puts(subfdout, "global environment dir: ");
 	substdio_puts(subfdout, controldir);
@@ -903,7 +910,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_showctl_c()
 {
-	static char    *x = "$Id: qmail-showctl.c,v 1.16 2023-12-31 08:57:39+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-showctl.c,v 1.17 2024-02-20 22:25:56+05:30 Cprogrammer Exp mbhangui $";
 
 	if (x)
 		x++;

--- a/indimail-mta-x/spawn-filter.9
+++ b/indimail-mta-x/spawn-filter.9
@@ -68,25 +68,25 @@ SPAM filters (See the section on SPAM Filtering). This file has the
 following format.
 
 .EX
-\fBdomain:args\fR
+ \fBdomain:args\fR
   or
-\fBdomain:args:envstr\fR
+ \fBdomain:args:envstr\fR
 .EE
 
 for both local and remote deliveries
 
 .EX
-\fBdomain:remote:args\fR
+ \fBdomain:remote:args\fR
   or
-\fBdomain:remote:args:envstr\fR
+ \fBdomain:remote:args:envstr\fR
 .EE
 
 for remote deliveries and
 
 .EX
-\fBdomain:local:args\fR
+ \fBdomain:local:args\fR
   or
-\fBdomain:local:args:envstr\fR
+ \fBdomain:local:args:envstr\fR
 .EE
 
 for local deliveries.
@@ -102,19 +102,24 @@ For remote deliveries, \fIdomain\fR refers to the sender domain. You can
 have the match done on recipient domain by setting
 \fBMATCH_RECIPIENT_DOMAIN\fR.
 
-.EX
-indimail.org:remote:PREFIX/sbin/qmail-dkim:DKIMQUEUE=/bin/cat
-.EE
-
 \fIenvstr\fR mentioned above is a string of environment variable additions
 or removals. e.g.
 
 .EX
-QREGEX=1,DKIMSIGNOPTIONS=-z 4,HOME=
+ QREGEX=1,DKIMSIGNOPTIONS=-z 4,HOME=
 .EE
 
 sets QREGEX to 1, DKIMSIGNOPTIONS to "-z 4" and unsets HOME envrionment
 variable.
+
+Here are two examples that calls qmail-dkim for DKIM signing / verification
+for all domains that end with \fB.org\fR. The first one uses regular
+expression and the second example uses simple wildcard match.
+
+.EX
+ .*\.org:remote:PREFIX/sbin/qmail-dkim:DKIMQUEUE=/bin/cat,QREGEX=1
+ *.org:remote:PREFIX/sbin/qmail-dkim:DKIMQUEUE=/bin/cat,QREGEX=
+.EE
 
 .TP 5
 .I databytes


### PR DESCRIPTION
1. indimail-mta.spec, DIRS.in: added control/filters.d for user defined filters
2. qmail-multi (mailfilter.c): added exit code 99 (blackhole) for compatibility with qmail-qfilter
3. qfrontend, qf-log-subject, qf-smtp-ratelimit: make script compatible with FILTERARGS as well as qmail-qfilter
4. qfrontend: use control/filters.d directory for user defined scripts
5. qmail-qfilter.c: added exit code 2 (blackhole) for compatibility with qmail-multi
6. qmail-showctl.c: added display of user filter directory control/filters.d